### PR TITLE
refactor: remove lava link hard coded search prefix

### DIFF
--- a/packages/lava-queue/src/queue.ts
+++ b/packages/lava-queue/src/queue.ts
@@ -106,6 +106,18 @@ export class Queue {
     this.lavaPlayer.pause(false);
   }
 
+  /**
+   * Track Searching
+   *
+   * Lavalink supports searching via YouTube, YouTube Music, and Soundcloud.
+   * To search, you must prefix your identifier with `ytsearch:`, `ytmsearch:`, or `scsearch:` respectively.
+   * When a search prefix is used, the returned `loadType` will be `SEARCH_RESULT`.
+   * Note that, disabling the respective source managers renders these search prefixes redundant.
+   * Plugins may also implement prefixes to allow for more search engines.
+   *
+   * @param text - User input
+   * @param searchEngine - lavalink search engine
+   */
   search(text: string, searchEngine = "ytsearch"): Promise<TrackResponse> {
     return this.player.node.load(`${searchEngine}:${text}`);
   }

--- a/packages/lava-queue/src/queue.ts
+++ b/packages/lava-queue/src/queue.ts
@@ -116,10 +116,9 @@ export class Queue {
    * Plugins may also implement prefixes to allow for more search engines.
    *
    * @param text - User input
-   * @param searchEngine - lavalink search engine
    */
-  search(text: string, searchEngine = "ytsearch"): Promise<TrackResponse> {
-    return this.player.node.load(`${searchEngine}:${text}`);
+  search(text: string): Promise<TrackResponse> {
+    return this.player.node.load(text);
   }
 
   setPosition(position: number): void {

--- a/packages/lava-queue/src/queue.ts
+++ b/packages/lava-queue/src/queue.ts
@@ -106,8 +106,8 @@ export class Queue {
     this.lavaPlayer.pause(false);
   }
 
-  search(text: string): Promise<TrackResponse> {
-    return this.player.node.load(`ytsearch:${text}`);
+  search(text: string, searchEngine = "ytsearch"): Promise<TrackResponse> {
+    return this.player.node.load(`${searchEngine}:${text}`);
   }
 
   setPosition(position: number): void {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently the search method has the search engine hardcoded, with this change you can choose what search engine to use and keep `ytsearch` as the default value

## Package
@discordx/lava-queue

- discordx
- @discordx/lava-queue
