### PR TITLE
Add test for duplicate command groups

### DIFF
--- a/packages/discordx/tests/slash.test.ts
+++ b/packages/discordx/tests/slash.test.ts
@@ -259,6 +259,7 @@ export class Group {
 
 @Discord()
 @SlashGroup({ name: "test-y" })
+@SlashGroup({ name: "add", root: "test-y" })
 @SlashGroup("test-y")
 export class DuplicateGroup {
   @Slash()

--- a/packages/discordx/tests/slash.test.ts
+++ b/packages/discordx/tests/slash.test.ts
@@ -257,6 +257,33 @@ export class Group {
   }
 }
 
+@Discord()
+@SlashGroup({ name: "test-y" })
+@SlashGroup("test-y")
+export class DuplicateGroup {
+    @Slash()
+    o(): unknown {
+      return ["/test-y", "o", true];
+    }
+  
+    @Slash()
+    p(): unknown {
+      return ["/test-y", "p", true];
+    }
+
+    @Slash()
+    @SlashGroup("add", "test-y")
+    y(): unknown {
+      return ["/test-y", "add", "y", true];
+    }
+
+    @Slash()
+    @SlashGroup("add", "test-y")
+    z(): unknown {
+      return ["/test-y", "add", "z", true];
+    }
+}
+
 const client = new Client({ intents: [] });
 
 beforeAll(async () => {
@@ -598,6 +625,54 @@ describe("Slash", () => {
             description: "n",
             descriptionLocalizations: null,
             name: "n",
+            nameLocalizations: null,
+            type: ApplicationCommandOptionType.Subcommand,
+          },
+        ],
+        type: ApplicationCommandType.ChatInput,
+      },
+      {
+        defaultMemberPermissions: null,
+        description: "test-y",
+        descriptionLocalizations: null,
+        dmPermission: true,
+        name: "test-y",
+        nameLocalizations: null,
+        options: [
+          {
+            description: "add - subcommandgroup",
+            descriptionLocalizations: null,
+            name: "add",
+            nameLocalizations: null,
+            options: [
+              {
+                description: "y",
+                descriptionLocalizations: null,
+                name: "y",
+                nameLocalizations: null,
+                type: ApplicationCommandOptionType.Subcommand,
+              },
+              {
+                description: "z",
+                descriptionLocalizations: null,
+                name: "z",
+                nameLocalizations: null,
+                type: ApplicationCommandOptionType.Subcommand,
+              },
+            ],
+            type: ApplicationCommandOptionType.SubcommandGroup,
+          },
+          {
+            description: "o",
+            descriptionLocalizations: null,
+            name: "o",
+            nameLocalizations: null,
+            type: ApplicationCommandOptionType.Subcommand,
+          },
+          {
+            description: "p",
+            descriptionLocalizations: null,
+            name: "p",
             nameLocalizations: null,
             type: ApplicationCommandOptionType.Subcommand,
           },

--- a/packages/discordx/tests/slash.test.ts
+++ b/packages/discordx/tests/slash.test.ts
@@ -261,27 +261,27 @@ export class Group {
 @SlashGroup({ name: "test-y" })
 @SlashGroup("test-y")
 export class DuplicateGroup {
-    @Slash()
-    o(): unknown {
-      return ["/test-y", "o", true];
-    }
-  
-    @Slash()
-    p(): unknown {
-      return ["/test-y", "p", true];
-    }
+  @Slash()
+  o(): unknown {
+    return ["/test-y", "o", true];
+  }
 
-    @Slash()
-    @SlashGroup("add", "test-y")
-    y(): unknown {
-      return ["/test-y", "add", "y", true];
-    }
+  @Slash()
+  p(): unknown {
+    return ["/test-y", "p", true];
+  }
 
-    @Slash()
-    @SlashGroup("add", "test-y")
-    z(): unknown {
-      return ["/test-y", "add", "z", true];
-    }
+  @Slash()
+  @SlashGroup("add", "test-y")
+  y(): unknown {
+    return ["/test-y", "add", "y", true];
+  }
+
+  @Slash()
+  @SlashGroup("add", "test-y")
+  z(): unknown {
+    return ["/test-y", "add", "z", true];
+  }
 }
 
 const client = new Client({ intents: [] });


### PR DESCRIPTION
This pull request adds a currently failing test to demonstrate that duplicate subgroups are currently going wrong. This does not have to be merged, this is mostly to provide a failing test for the issue I'm having.

With this added logic, the library should generate the following:

```
/test-x m
/test-x n
/test-x add y
/test-x add x
/test-y o
/test-y p
/test-y add y
/test-y add z
```

However at the time of the pull request the following is produced:

```
/test-x m
/test-x n
/test-x add z
/test-x add y
/test-x add y
/test-x add x
/test-y o
/test-y p
```

## Package
- discordx
