### PR TITLE
fix(lava-queue): do not add song to the end of queue

### DIFF
--- a/packages/lava-queue/src/queue.ts
+++ b/packages/lava-queue/src/queue.ts
@@ -80,7 +80,7 @@ export class Queue {
 
   playNext(): boolean {
     if (this.currentTrack) {
-      if (this.loop) {
+      if (this.loop && !this.repeat) {
         this.tracks.push(this.currentTrack);
       }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently if the queue is both on loop and on repeat, it keeps adding the song to the end of queue instead of just adding it to the beginning of the queue

## Package

- @discordx/lava-queue