### PR TITLE
fix(utilities): emitter decorator does not contain user obj

### DIFF
--- a/packages/utilities/src/guards/NotBot/index.ts
+++ b/packages/utilities/src/guards/NotBot/index.ts
@@ -57,7 +57,7 @@ export const NotBot: GuardFunction<
         argObj instanceof StringSelectMenuInteraction ||
         argObj instanceof UserSelectMenuInteraction
       ? argObj.member?.user
-      : argObj.message.author;
+      : argObj.message?.author;
 
   if (!user?.bot) {
     await next();


### PR DESCRIPTION
This fix allows the user to be undefined, which still meets the intent of the guard.

#904 

This will fix a bug using discordx global guards and discordx emitter decorators.

## Package

<!--
Lines that apply to you should be moved out of the comment
- discordx
- @discordx/music
- @discordx/utilities
-->
