### PR TITLE
feat(discordx): plugins support

### DIFF
--- a/docs/docs/discordx/basics/plugin.md
+++ b/docs/docs/discordx/basics/plugin.md
@@ -1,0 +1,29 @@
+# Plugin
+
+Develop plugins for discordx. You can publish your plugin on NPM. Maintain a single codebase while using them on different bots.
+
+## Create a Plugin
+
+```ts
+import { dirname, importx } from "@discordx/importer";
+import { Plugin } from "discordx";
+
+export class HelperPlugin extends Plugin {
+  async init(): Promise<void> {
+    // This section is similar to the bot login section. However, here we are doing this for a plugin.
+    await importx(`${dirname(import.meta.url)}/commands/**/*.{js,ts}`);
+  }
+}
+```
+
+## Use a plugin with discordx client
+
+```ts
+import { Client, MetadataStorage } from "discordx";
+
+// Initialize the plugin
+const helperPlugin = new HelperPlugin({ metadata: MetadataStorage.instance });
+
+// Provide plugins to client
+new Client({ plugins: [helperPlugin] });
+```

--- a/packages/discordx/examples/plugin/main.ts
+++ b/packages/discordx/examples/plugin/main.ts
@@ -1,0 +1,46 @@
+import { IntentsBitField } from "discord.js";
+
+import { Client, MetadataStorage } from "../../src/index.js";
+import { HelperPlugin } from "./plugin/plugin.js";
+
+const helperPlugin = new HelperPlugin({ metadata: MetadataStorage.instance });
+
+export class Main {
+  private static _client: Client;
+
+  static get Client(): Client {
+    return this._client;
+  }
+
+  static async start(): Promise<void> {
+    this._client = new Client({
+      // botGuilds: [(client) => client.guilds.cache.map((guild) => guild.id)],
+      intents: [
+        IntentsBitField.Flags.Guilds,
+        IntentsBitField.Flags.GuildMessages,
+        IntentsBitField.Flags.GuildMembers,
+        IntentsBitField.Flags.GuildMessageReactions,
+      ],
+      plugins: [helperPlugin],
+      silent: false,
+    });
+
+    this._client.once("ready", async () => {
+      await this._client.initApplicationCommands();
+
+      console.log("Bot started");
+    });
+
+    this._client.on("interactionCreate", (interaction) => {
+      this._client.executeInteraction(interaction);
+    });
+
+    // let's start the bot
+    if (!process.env.BOT_TOKEN) {
+      throw Error("Could not find BOT_TOKEN in your environment");
+    }
+    await this._client.login(process.env.BOT_TOKEN);
+  }
+}
+
+Main.start();

--- a/packages/discordx/examples/plugin/plugin/commands/help.ts
+++ b/packages/discordx/examples/plugin/plugin/commands/help.ts
@@ -1,0 +1,14 @@
+import type { CommandInteraction } from "discord.js";
+
+import { Discord, Slash } from "../../../../src/index.js";
+
+@Discord()
+export class Example {
+  @Slash({
+    description: "help command",
+    name: "help",
+  })
+  help(interaction: CommandInteraction): void {
+    interaction.reply("I am help command xd.");
+  }
+}

--- a/packages/discordx/examples/plugin/plugin/plugin.ts
+++ b/packages/discordx/examples/plugin/plugin/plugin.ts
@@ -1,0 +1,9 @@
+import { dirname, importx } from "@discordx/importer";
+
+import { Plugin } from "../../../src/index.js";
+
+export class HelperPlugin extends Plugin {
+  async init(): Promise<void> {
+    await importx(`${dirname(import.meta.url)}/commands/**/*.{js,ts}`);
+  }
+}

--- a/packages/discordx/examples/plugin/tsconfig.json
+++ b/packages/discordx/examples/plugin/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "strict": true,
+    "noImplicitAny": true,
+    "outDir": "build",
+    "emitDecoratorMetadata": false,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules", "tests", "examples"]
+}

--- a/packages/discordx/src/Client.ts
+++ b/packages/discordx/src/Client.ts
@@ -45,6 +45,7 @@ import type {
   IPrefixResolver,
   ISimpleCommandByName,
   ITriggerEventData,
+  Plugin,
   SimpleCommandConfig,
 } from "./index.js";
 import {
@@ -72,6 +73,7 @@ export class Client extends ClientJS {
   private _simpleCommandConfig?: SimpleCommandConfig;
   private _silent: boolean;
   private _botGuilds: IGuild[] = [];
+  private _plugins: Plugin[] = [];
   private _guards: GuardFunction[] = [];
   private logger: ILogger;
 
@@ -288,6 +290,7 @@ export class Client extends ClientJS {
   constructor(options: ClientOptions) {
     super(options);
 
+    this._plugins = options?.plugins ?? [];
     this._silent = options?.silent ?? true;
     this.guards = options.guards ?? [];
     this.botGuilds = options.botGuilds ?? [];
@@ -1387,6 +1390,8 @@ export class Client extends ClientJS {
     if (this._isBuilt) {
       return;
     }
+
+    await Promise.all(this._plugins.map((plugin) => plugin.init()));
 
     this._isBuilt = true;
     await this.instance.build();

--- a/packages/discordx/src/logic/index.ts
+++ b/packages/discordx/src/logic/index.ts
@@ -1,1 +1,2 @@
 export * from "./metadata/MetadataStorage.js";
+export * from "./plugin.js";

--- a/packages/discordx/src/logic/plugin.ts
+++ b/packages/discordx/src/logic/plugin.ts
@@ -1,0 +1,14 @@
+import type { Awaitable } from "../types/index.js";
+import { MetadataStorage } from "./metadata/MetadataStorage.js";
+
+export interface PluginConfiguration {
+  metadata: MetadataStorage;
+}
+
+export abstract class Plugin {
+  constructor(options: PluginConfiguration) {
+    MetadataStorage.instance = options.metadata;
+  }
+
+  abstract init(): Awaitable<void>;
+}

--- a/packages/discordx/src/types/core/ClientOptions.ts
+++ b/packages/discordx/src/types/core/ClientOptions.ts
@@ -3,7 +3,12 @@ import type {
   Message,
 } from "discord.js";
 
-import type { ArgSplitter, GuardFunction, IGuild } from "../../index.js";
+import type {
+  ArgSplitter,
+  GuardFunction,
+  IGuild,
+  Plugin,
+} from "../../index.js";
 import type { Awaitable, ILogger, IPrefixResolver } from "../index.js";
 
 export type SimpleCommandConfig = {
@@ -48,6 +53,11 @@ export interface ClientOptions extends DiscordJSClientOptions {
    * Set custom logger implementation
    */
   logger?: ILogger;
+
+  /**
+   * Set of plugins
+   */
+  plugins?: Plugin[];
 
   /**
    * Do not log anything


### PR DESCRIPTION
# Plugin

Develop plugins for discordx. You can publish your plugin on NPM. Maintain a single codebase while using them on different bots.

## Create a Plugin

```ts
import { dirname, importx } from "@discordx/importer";
import { Plugin } from "discordx";

export class HelperPlugin extends Plugin {
  async init(): Promise<void> {
    // This section is similar to the bot login section. However, here we are doing this for a plugin.
    await importx(`${dirname(import.meta.url)}/commands/**/*.{js,ts}`);
  }
}
```

## Use a plugin with discordx client

```ts
import { Client, MetadataStorage } from "discordx";

// Initialize the plugin
const helperPlugin = new HelperPlugin({ metadata: MetadataStorage.instance });

// Provide plugins to client
new Client({ plugins: [helperPlugin] });
```

 # To-Do
 - [ ] Explain Plugin abstract class in document