### PR TITLE
refactor(discordx): add nsfw option to slash command objs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,4 @@
 {
-  "semi": true
+  "semi": true,
+  "endOfLine": "auto"
 }

--- a/packages/discordx/src/decorators/classes/DApplicationCommand.ts
+++ b/packages/discordx/src/decorators/classes/DApplicationCommand.ts
@@ -96,14 +96,14 @@ export class DApplicationCommand extends Method {
   set name(value: string) {
     this._name = value;
   }
-  
+
   get nameLocalizations(): LocalizationMap | null {
     return this._nameLocalizations;
   }
   set nameLocalizations(value: LocalizationMap | null) {
     this._nameLocalizations = value;
   }
-  
+
   get nsfw(): boolean {
     return this._nsfw;
   }

--- a/packages/discordx/src/decorators/classes/DApplicationCommand.ts
+++ b/packages/discordx/src/decorators/classes/DApplicationCommand.ts
@@ -19,6 +19,7 @@ type CreateStructure = {
   guilds?: IGuild[];
   name: string;
   nameLocalizations?: LocalizationMap | null;
+  nsfw?: boolean;
   type: ApplicationCommandType;
 };
 
@@ -35,6 +36,7 @@ export class DApplicationCommand extends Method {
   private _dmPermission: boolean;
   private _guilds: IGuild[];
   private _group?: string;
+  private _nsfw: boolean;
   private _options: DApplicationCommandOption[] = [];
   private _subgroup?: string;
   private _type: ApplicationCommandType;
@@ -94,12 +96,19 @@ export class DApplicationCommand extends Method {
   set name(value: string) {
     this._name = value;
   }
-
+  
   get nameLocalizations(): LocalizationMap | null {
     return this._nameLocalizations;
   }
   set nameLocalizations(value: LocalizationMap | null) {
     this._nameLocalizations = value;
+  }
+  
+  get nsfw(): boolean {
+    return this._nsfw;
+  }
+  set nsfw(value: boolean) {
+    this._nsfw = value;
   }
 
   get options(): DApplicationCommandOption[] {
@@ -132,6 +141,7 @@ export class DApplicationCommand extends Method {
     this._botIds = data.botIds ?? [];
     this._descriptionLocalizations = data.descriptionLocalizations ?? null;
     this._nameLocalizations = data.nameLocalizations ?? null;
+    this._nsfw = data.nsfw ?? false;
     this._dmPermission = data.dmPermission ?? true;
     this._defaultMemberPermissions = data.defaultMemberPermissions ?? null;
   }

--- a/packages/discordx/src/decorators/decorators/Slash.ts
+++ b/packages/discordx/src/decorators/decorators/Slash.ts
@@ -38,6 +38,7 @@ export function Slash<T extends string, TD extends string>(
       guilds: options?.guilds,
       name: name,
       nameLocalizations: options?.nameLocalizations,
+      nsfw: options?.nsfw,
       type: ApplicationCommandType.ChatInput,
     }).decorate(target.constructor, key, target[key]);
 

--- a/packages/discordx/src/types/public/slash.ts
+++ b/packages/discordx/src/types/public/slash.ts
@@ -22,6 +22,7 @@ export type ApplicationCommandOptions<T extends string, TD extends string> = {
   dmPermission?: boolean;
   guilds?: IGuild[];
   name?: T;
+  nsfw?: boolean;
   nameLocalizations?: LocalizationMap;
 };
 
@@ -115,6 +116,7 @@ export type ApplicationCommandDataEx = {
   dmPermission?: boolean;
   name: string;
   nameLocalizations?: LocalizationMap | null;
+  nsfw?: boolean;
   options: ApplicationCommandOptionData[];
   type: ApplicationCommandType;
 };

--- a/packages/discordx/src/types/public/slash.ts
+++ b/packages/discordx/src/types/public/slash.ts
@@ -22,8 +22,8 @@ export type ApplicationCommandOptions<T extends string, TD extends string> = {
   dmPermission?: boolean;
   guilds?: IGuild[];
   name?: T;
-  nsfw?: boolean;
   nameLocalizations?: LocalizationMap;
+  nsfw?: boolean;
 };
 
 export type SlashOptionBaseOptions<T extends string, TD extends string> = {

--- a/packages/discordx/src/util/comparison.ts
+++ b/packages/discordx/src/util/comparison.ts
@@ -68,7 +68,7 @@ export function isApplicationCommandEqual(
   // replace null fields with undefined
   RecursivelyMatchField(
     commandJson,
-    ["descriptionLocalized", "nameLocalized", "dmPermission"],
+    ["descriptionLocalized", "nameLocalized", "dmPermission", "nsfw"],
     (object: any, key: string) => {
       if (object[key] === null) {
         object[key] = undefined;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added `nsfw` option to slash decorator to match [discord api types](https://discord-api-types.dev/api/discord-api-types-v10/interface/APIApplicationCommand)

## Package
- discordx
<!--
Lines that apply to you should be moved out of the comment
- @discordx/music
- @discordx/utilities
-->
