### PR TITLE
fix(discordx): add missing nsfw prop to json

### DIFF
--- a/packages/discordx/src/decorators/classes/DApplicationCommand.ts
+++ b/packages/discordx/src/decorators/classes/DApplicationCommand.ts
@@ -221,6 +221,7 @@ export class DApplicationCommand extends Method {
       dmPermission: this.dmPermission,
       name: this.name,
       nameLocalizations: this.nameLocalizations,
+      nsfw: this.nsfw,
       options: options,
       type: this.type,
     };

--- a/packages/discordx/src/types/public/slash.ts
+++ b/packages/discordx/src/types/public/slash.ts
@@ -117,6 +117,7 @@ export type ApplicationCommandDataEx = {
   dmPermission?: boolean;
   name: string;
   nameLocalizations?: LocalizationMap | null;
+  nsfw?: boolean;
   options: ApplicationCommandOptionData[];
   type: ApplicationCommandType;
 };

--- a/packages/discordx/tests/slash-choice.test.ts
+++ b/packages/discordx/tests/slash-choice.test.ts
@@ -114,6 +114,7 @@ describe("Choice", () => {
         dmPermission: true,
         name: "hello",
         nameLocalizations: null,
+        nsfw: false,
         options: [
           {
             choices: [
@@ -145,6 +146,7 @@ describe("Choice", () => {
         dmPermission: true,
         name: "number",
         nameLocalizations: null,
+        nsfw: false,
         options: [
           {
             choices: [
@@ -186,6 +188,7 @@ describe("Choice", () => {
         dmPermission: true,
         name: "string",
         nameLocalizations: null,
+        nsfw: false,
         options: [
           {
             choices: [

--- a/packages/discordx/tests/slash-group.test.ts
+++ b/packages/discordx/tests/slash-group.test.ts
@@ -288,6 +288,7 @@ describe("Choice", () => {
         dmPermission: true,
         name: "testing",
         nameLocalizations: null,
+        nsfw: false,
         options: [
           {
             description: "hello",
@@ -425,6 +426,7 @@ describe("Choice", () => {
         dmPermission: true,
         name: "group-test-without-description",
         nameLocalizations: null,
+        nsfw: false,
         options: [
           {
             description: "text group description",
@@ -470,6 +472,7 @@ describe("Choice", () => {
         dmPermission: true,
         name: "test-x",
         nameLocalizations: null,
+        nsfw: false,
         options: [
           {
             description: "add",
@@ -518,6 +521,7 @@ describe("Choice", () => {
         dmPermission: true,
         name: "test-y",
         nameLocalizations: null,
+        nsfw: false,
         options: [
           {
             description: "add",

--- a/packages/discordx/tests/slash.test.ts
+++ b/packages/discordx/tests/slash.test.ts
@@ -68,6 +68,7 @@ describe("Slash", () => {
         dmPermission: true,
         name: "hello",
         nameLocalizations: null,
+        nsfw: false,
         options: [
           {
             description: "text",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds missing nsfw property to obj that hits discord

## Package
- discordx
<!--
Lines that apply to you should be moved out of the comment
- @discordx/music
- @discordx/utilities
-->
