### PR TITLE
chore(di): fix tokenization injection

### DIFF
--- a/docs/docs/discordx/basics/dependencyInjection.md
+++ b/docs/docs/discordx/basics/dependencyInjection.md
@@ -49,8 +49,8 @@ import { DIService, typeDiDependencyRegistryEngine } from "discordx";
 import { Container, Service } from "typedi";
 
 DIService.engine = typeDiDependencyRegistryEngine
-    .setService(Service)
-    .setInjector(Container);
+  .setService(Service)
+  .setInjector(Container);
 ```
 
 ```ts title="customEngine"
@@ -160,8 +160,11 @@ e.g `tsyringeDependencyRegistryEngine.token`.
 ### Enabling
 
 In order to enable Discord x to use tokenization, you simply need to call `setUseTokenization(true)` on your initialization of Discordx I.E:
+
 ```ts
-DIService.engine = tsyringeDependencyRegistryEngine.setUseTokenization(true).setInjector(container);
+DIService.engine = tsyringeDependencyRegistryEngine
+  .setUseTokenization(true)
+  .setInjector(container);
 ```
 
 ### Custom Tsyringe tokens
@@ -172,20 +175,19 @@ In order to set your own custom token, you must call `TsyringeDependencyRegistry
 
 for TypeDI, it is the same as for Tsyringe except you need to call `TypeDiDependencyRegistryEngine.setToken` and pass in an instance of TypeDI's Token class
 
-
 ### usage
 
 To use this. just use `TsyringeDependencyRegistryEngine.token` when you want to get all of Discordx's decorated classes. I.E
+
 ```ts
 @injectable()
 class TsClass {
-    public constructor(
-        @injectAll(TsyringeDependencyRegistryEngine.token) discordClasses: unknown[]
-    ) {
-        console.log(discordClasses) // all of Discordx's classes
-    }
+  public constructor(
+    @injectAll(TsyringeDependencyRegistryEngine.token) discordClasses: unknown[]
+  ) {
+    console.log(discordClasses); // all of Discordx's classes
+  }
 }
-
 ```
 
 #### Side-effects

--- a/docs/docs/discordx/basics/dependencyInjection.md
+++ b/docs/docs/discordx/basics/dependencyInjection.md
@@ -49,8 +49,8 @@ import { DIService, typeDiDependencyRegistryEngine } from "discordx";
 import { Container, Service } from "typedi";
 
 DIService.engine = typeDiDependencyRegistryEngine
-  .setService(Service)
-  .setInjector(Container);
+    .setService(Service)
+    .setInjector(Container);
 ```
 
 ```ts title="customEngine"
@@ -157,68 +157,51 @@ the `tsyringeDependencyRegistryEngine` and `typeDiDependencyRegistryEngine` both
 services with tokens, the tokens are available by static props on the classes:
 e.g `tsyringeDependencyRegistryEngine.token`.
 
-This means that in order to get a class from the container of these, you will need to supply a token or
-call `DIService.instance.getService(DiscordService);`.
+### Enabling
 
-Because of thw way that TypeDI and tsyringe deals with tokens, if you simply inject a `@Discord` class it will create a
-NEW instance of that class, and it will not be a singleton, this is because any class registered with a token can only
-be retrieved with that token.
+In order to enable Discord x to use tokenization, you simply need to call `setUseTokenization(true)` on your initialization of Discordx I.E:
+```ts
+DIService.engine = tsyringeDependencyRegistryEngine.setUseTokenization(true).setInjector(container);
+```
 
-So, by default, tokens on TypeDI and tsyringe are disabled, to enable them,
-call `tsyringeDependencyRegistryEngine.setUseTokenization(true);`
-or `typeDiDependencyRegistryEngine.setUseTokenization(true);`
+### Custom Tsyringe tokens
 
-If you enable tokens on tsyringe or TypeDI, it would mean that you would have to use `@InjectAll` then do a filter on
+In order to set your own custom token, you must call `TsyringeDependencyRegistryEngine.setToken` and pass in the symbol you wish to use. and Discordx will internally use this symbol. by default, this is set to `Symbol("discordx")`
+
+### Custom TypeDI tokens
+
+for TypeDI, it is the same as for Tsyringe except you need to call `TypeDiDependencyRegistryEngine.setToken` and pass in an instance of TypeDI's Token class
+
+
+### usage
+
+To use this. just use `TsyringeDependencyRegistryEngine.token` when you want to get all of Discordx's decorated classes. I.E
+```ts
+@injectable()
+class TsClass {
+    public constructor(
+        @injectAll(TsyringeDependencyRegistryEngine.token) discordClasses: unknown[]
+    ) {
+        console.log(discordClasses) // all of Discordx's classes
+    }
+}
+
+```
+
+#### Side-effects
+
+Due to the nature of tokens and how the internal resolution factory of both systems resolve classes. you must be careful when you use tokens.
+
+Discordx handles internal Tsyringe tokenization by proxying the into an `Instance Cashing Singleton Factory`. this factory allowes both tokens AND classes to be resolved by the same registry.
+
+in short, this allowes you to use `@injectALl(TypeDiDependencyRegistryEngine.token)` to get all of Discordx's classes AND a normal injection of a single class, and you can be sure that both the standard injection and the token injection will ALWAYS resolve the same singleton.
+
+so if you use TypeDI to get ALL of your classes, you will need a custom filter on the injection constructor:
 that array to find the class.
-
-For example, if you wanted to get the `OnReady.ts` class:
-
-```ts title="useTokenization=true"
-@Discord()
-class OnReady {
-  private bar = "bar";
-  public foo() {
-    console.log(this.bar);
-  }
-}
-
-@injectable()
-class TsClass {
-  private onReady: OnReady | null;
-
-  public constructor(
-    @injectAll(tsyringeDependencyRegistryEngine.token) discordClasses: unknown[]
-  ) {
-    this.onReady =
-      discordClasses.find((service) => service.constructor === OnReady) ?? null;
-    // or
-    this.onReady = DIService.getService(OnReady);
-
-    this.onReady.foo();
-  }
-}
-```
-
-```ts title="useTokenization=false"
-@Discord()
-class OnReady {
-  private bar = "bar";
-  public foo() {
-    console.log(this.bar);
-  }
-}
-
-@injectable()
-class TsClass {
-  public constructor(private onReady: OnReady) {
-    onReady.foo();
-  }
-}
-```
 
 ## Getting all @Discord classes
 
-If for some reason, you wish to get all instances of the `@Discord` classes in your bot, then you can simple
+if you wish to get all instances of the `@Discord` classes in your bot, then you can simple
 call `DIService.allServices();`
 
 **NOTE**: this will construct all your classes in the DI container, if you wish to lazy-load your Discord classes, then
@@ -229,5 +212,23 @@ import { DIService } from "discordx";
 
 function getAllDiscordClasses(): Set<unknown> {
   return DIService.allServices();
+}
+```
+
+And if you are using tokens:
+
+```ts title="Tsyringe tokens"
+import { DIService } from "discordx";
+
+function getAllDiscordClasses(): Set<unknown> {
+  return container.resolveAll(TsyringeDependencyRegistryEngine.token);
+}
+```
+
+```ts title="typeDi tokens"
+import { DIService } from "discordx";
+
+function getAllDiscordClasses(): Set<unknown> {
+  return Container.getMany(TypeDiDependencyRegistryEngine.token);
 }
 ```

--- a/packages/di/src/logic/impl/TsyringeDependencyRegistryEngine.ts
+++ b/packages/di/src/logic/impl/TsyringeDependencyRegistryEngine.ts
@@ -17,7 +17,7 @@ export class TsyringeDependencyRegistryEngine extends AbstractConfigurableDepend
   public static get instance(): TsyringeDependencyRegistryEngine {
     if (!TsyringeDependencyRegistryEngine._instance) {
       TsyringeDependencyRegistryEngine._instance =
-          new TsyringeDependencyRegistryEngine();
+        new TsyringeDependencyRegistryEngine();
     }
 
     return TsyringeDependencyRegistryEngine._instance;
@@ -30,7 +30,7 @@ export class TsyringeDependencyRegistryEngine extends AbstractConfigurableDepend
     this._serviceSet.add(classType);
     const clazz = classType as unknown as new () => InstanceOf<T>;
     const instanceCashingSingletonFactory: FactoryFunction<unknown> =
-        this.getInstanceCashingSingletonFactory(clazz);
+      this.getInstanceCashingSingletonFactory(clazz);
     if (this.useToken) {
       this.injector.register(TsyringeDependencyRegistryEngine.token, {
         useFactory: instanceCashingSingletonFactory,
@@ -47,12 +47,12 @@ export class TsyringeDependencyRegistryEngine extends AbstractConfigurableDepend
     const clazz = classType as unknown as new () => InstanceOf<T>;
     if (this.useToken && !container.isRegistered(clazz)) {
       return (
-          (this.injector
-              .resolveAll(TsyringeDependencyRegistryEngine.token)
-              .find(
-                  (instance) =>
-                      (instance as Record<string, unknown>).constructor === clazz
-              ) as InstanceOf<T>) ?? null
+        (this.injector
+          .resolveAll(TsyringeDependencyRegistryEngine.token)
+          .find(
+            (instance) =>
+              (instance as Record<string, unknown>).constructor === clazz
+          ) as InstanceOf<T>) ?? null
       );
     }
     return this.injector.resolve(clazz);
@@ -65,7 +65,7 @@ export class TsyringeDependencyRegistryEngine extends AbstractConfigurableDepend
 
     if (this.useToken) {
       return new Set(
-          this.injector.resolveAll(TsyringeDependencyRegistryEngine.token)
+        this.injector.resolveAll(TsyringeDependencyRegistryEngine.token)
       );
     }
 
@@ -83,7 +83,7 @@ export class TsyringeDependencyRegistryEngine extends AbstractConfigurableDepend
   }
 
   private getInstanceCashingSingletonFactory<T>(
-      clazz: InjectionToken<T>
+    clazz: InjectionToken<T>
   ): FactoryFunction<T> {
     return instanceCachingFactory<T>((c) => {
       if (!c.isRegistered(clazz)) {

--- a/packages/di/src/logic/impl/TypeDiDependencyRegistryEngine.ts
+++ b/packages/di/src/logic/impl/TypeDiDependencyRegistryEngine.ts
@@ -6,7 +6,7 @@ import type { InstanceOf } from "../../index.js";
 import { AbstractConfigurableDependencyInjector } from "../AbstractConfigurableDependencyInjector.js";
 
 export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependencyInjector<
-    typeof Container
+  typeof Container
 > {
   public static token = new Token<unknown>("discordx");
 
@@ -17,7 +17,7 @@ export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependen
   public static get instance(): TypeDiDependencyRegistryEngine {
     if (!TypeDiDependencyRegistryEngine._instance) {
       TypeDiDependencyRegistryEngine._instance =
-          new TypeDiDependencyRegistryEngine();
+        new TypeDiDependencyRegistryEngine();
     }
 
     return TypeDiDependencyRegistryEngine._instance;
@@ -57,7 +57,7 @@ export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependen
 
     if (this.useToken) {
       return new Set(
-          this.injector.getMany(TypeDiDependencyRegistryEngine.token)
+        this.injector.getMany(TypeDiDependencyRegistryEngine.token)
       );
     }
 
@@ -76,13 +76,13 @@ export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependen
 
     if (this.useToken) {
       return (
-          (this.injector
-              .getMany(TypeDiDependencyRegistryEngine.token)
-              .find(
-                  (clazz) =>
-                      ((clazz as Record<string, unknown>)
-                          .constructor as unknown as T) === classType
-              ) as InstanceOf<T>) ?? null
+        (this.injector
+          .getMany(TypeDiDependencyRegistryEngine.token)
+          .find(
+            (clazz) =>
+              ((clazz as Record<string, unknown>)
+                .constructor as unknown as T) === classType
+          ) as InstanceOf<T>) ?? null
       );
     }
 

--- a/packages/di/src/logic/impl/TypeDiDependencyRegistryEngine.ts
+++ b/packages/di/src/logic/impl/TypeDiDependencyRegistryEngine.ts
@@ -6,9 +6,9 @@ import type { InstanceOf } from "../../index.js";
 import { AbstractConfigurableDependencyInjector } from "../AbstractConfigurableDependencyInjector.js";
 
 export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependencyInjector<
-  typeof Container
+    typeof Container
 > {
-  public static readonly token = new Token<unknown>("discordx");
+  public static token = new Token<unknown>("discordx");
 
   private static _instance: TypeDiDependencyRegistryEngine;
 
@@ -17,7 +17,7 @@ export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependen
   public static get instance(): TypeDiDependencyRegistryEngine {
     if (!TypeDiDependencyRegistryEngine._instance) {
       TypeDiDependencyRegistryEngine._instance =
-        new TypeDiDependencyRegistryEngine();
+          new TypeDiDependencyRegistryEngine();
     }
 
     return TypeDiDependencyRegistryEngine._instance;
@@ -45,6 +45,11 @@ export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependen
     return this;
   }
 
+  public setToken<T>(token: Token<T>): this {
+    TypeDiDependencyRegistryEngine.token = token;
+    return this;
+  }
+
   public getAllServices(): Set<unknown> {
     if (!this.injector) {
       throw new Error("Please set the Service!");
@@ -52,7 +57,7 @@ export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependen
 
     if (this.useToken) {
       return new Set(
-        this.injector.getMany(TypeDiDependencyRegistryEngine.token)
+          this.injector.getMany(TypeDiDependencyRegistryEngine.token)
       );
     }
 
@@ -71,13 +76,13 @@ export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependen
 
     if (this.useToken) {
       return (
-        (this.injector
-          .getMany(TypeDiDependencyRegistryEngine.token)
-          .find(
-            (clazz) =>
-              ((clazz as Record<string, unknown>)
-                .constructor as unknown as T) === classType
-          ) as InstanceOf<T>) ?? null
+          (this.injector
+              .getMany(TypeDiDependencyRegistryEngine.token)
+              .find(
+                  (clazz) =>
+                      ((clazz as Record<string, unknown>)
+                          .constructor as unknown as T) === classType
+              ) as InstanceOf<T>) ?? null
       );
     }
 

--- a/packages/discordx/examples/di/tsyringe/commands/TokenInjection.ts
+++ b/packages/discordx/examples/di/tsyringe/commands/TokenInjection.ts
@@ -26,8 +26,8 @@ export class ExampleToken {
     // I am just a empty constructor :(
   }
 
-  @Slash({ description: "tsyringe" })
-  tsyringe_token(interaction: CommandInteraction): void {
+  @Slash({ description: "tsyringe", name: "tsyringe_token" })
+  tsyringe(interaction: CommandInteraction): void {
     if (DIService.engine === tsyringeDependencyRegistryEngine) {
       const allDiscordClasses = container.resolveAll(
         TsyringeDependencyRegistryEngine.token

--- a/packages/discordx/examples/di/tsyringe/commands/TokenInjection.ts
+++ b/packages/discordx/examples/di/tsyringe/commands/TokenInjection.ts
@@ -1,0 +1,46 @@
+import type { CommandInteraction } from "discord.js";
+import { container, injectable, singleton } from "tsyringe";
+
+import { tsyringeDependencyRegistryEngine } from "../../../../../di/src/index.js";
+import { TsyringeDependencyRegistryEngine } from "../../../../../di/src/logic/impl/index.js";
+import { Discord, DIService, Slash } from "../../../../src/index.js";
+
+@singleton()
+class Database {
+  database: string;
+
+  constructor() {
+    console.log("I am database");
+    this.database = "connected";
+  }
+
+  query() {
+    return this.database;
+  }
+}
+
+@Discord()
+@injectable()
+export class ExampleToken {
+  constructor(private database: Database) {
+    // I am just a empty constructor :(
+  }
+
+  @Slash({ description: "tsyringe" })
+  tsyringe_token(interaction: CommandInteraction): void {
+    if (DIService.engine === tsyringeDependencyRegistryEngine) {
+      const allDiscordClasses = container.resolveAll(
+        TsyringeDependencyRegistryEngine.token
+      );
+      const clazz = container.resolve(ExampleToken);
+      const resolvedClassInTokenisedClasses = allDiscordClasses.includes(clazz);
+      interaction.reply(
+        `${clazz.database.query()}, same class: ${
+          clazz === this
+        }\ntokenized class included in resolved class: ${resolvedClassInTokenisedClasses}`
+      );
+    } else {
+      interaction.reply("Not using TSyringe");
+    }
+  }
+}

--- a/packages/discordx/examples/di/tsyringe/commands/TokenInjection.ts
+++ b/packages/discordx/examples/di/tsyringe/commands/TokenInjection.ts
@@ -22,7 +22,7 @@ class Database {
 @Discord()
 @injectable()
 export class ExampleToken {
-  constructor(private database: Database) {
+  constructor(private readonly database: Database) {
     // I am just a empty constructor :(
   }
 

--- a/packages/discordx/examples/di/tsyringe/commands/common.ts
+++ b/packages/discordx/examples/di/tsyringe/commands/common.ts
@@ -21,7 +21,7 @@ class Database {
 @Discord()
 @injectable()
 export class Example {
-  constructor(private database: Database) {
+  constructor(private readonly database: Database) {
     // I am just a empty constructor :(
   }
 


### PR DESCRIPTION
DI tokenization was broken, well, more hacked than broken for Tsyringe. It was a long time coming, but we needed a way that we can resolve tokenized items from the registry without dual singleton creation when wanting to get the same item from the container.

I originally created a method to get items and filter them each time. this imposed multiple issues:

- it's slow
- it caused ALL discordx dependancies to be resolved every time they where asked
- it broke lazy loading

In order to solve this issue, i created an `Instance Cashing Singleton Factory` that, when an item from a token is resolved, would register the same token via the singleton factory and return that same item back to the container, effectivally registerting the class in BOTH the symbol and the constructor as a token. 

This speeds up the resolution using symbols as tokens and allows us to effectivally manage, produce and resolve multiple types of tokens under the same cross-cutting concern. you don't need to encaplusate the same module anymore as the container will create 2 tokens for the same object. 

## Breaking changes

If you are using tokenization in Tsyringe using the previous filter method, then you might want to revert back to the standard method of injection

## What about TypeDI?

I dunno lol

## Package

- @discordx/di


This has been tested by running the examples on my own test bot.