### PR TITLE
fix: typedi example tsconfig.json

### DIFF
--- a/packages/discordx/examples/di/typedi/tsconfig.json
+++ b/packages/discordx/examples/di/typedi/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "noImplicitAny": true,
     "outDir": "build",
-    "emitDecoratorMetadata": false,
+    "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,
     "strictNullChecks": true,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Set `emitDecoratorMetadata` to true because typedi requires it to be true, provides a better reference for example.

## Package
- discordx
<!--
Lines that apply to you should be moved out of the comment
- @discordx/music
- @discordx/utilities
-->
