### PR TITLE
doc: reconnect minlinked links as possible as many

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -335,3 +335,11 @@ The following documents can help you sort out issues with GitHub accounts and mu
 - https://stackoverflow.com/questions/37245303/what-does-usera-committed-with-userb-13-days-ago-on-github-mean
 - https://help.github.com/articles/about-commit-email-addresses/
 - https://help.github.com/articles/blocking-command-line-pushes-that-expose-your-personal-email-address/
+
+[coc]: #coc
+[github]: https://github.com/discordx-ts
+[js-style-guide]: https://google.github.io/styleguide/jsguide.html
+[commit-message-format]: https://github.com/discordx-ts/discordx/blob/main/.github/COMMIT_CONVENTION.md
+[dev-doc]: #submit-pr
+[individual-cla]: #cla
+[corporate-cla]: #cla


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

some hyperlinks are broken in [CONTRIBUTING.md](https://github.com/discordx-ts/discordx/blob/main/.github/CONTRIBUTING.md).

![image](https://github.com/discordx-ts/discordx/assets/60801210/990dbe91-007d-4e98-854c-ae034937ad4f)

if those syntaxes should work, they should have their own link URL like [CODE_OF_CONDUCT.md](https://github.com/discordx-ts/discordx/blob/main/.github/CODE_OF_CONDUCT.md?plain=1#L124)

so I added URLs as possible as many, but not all of them because I could not find them.

* [coc]: seems like just #coc heading link.
* [github]: *our [GitHub Repository]* means this repository.
* [js-style-guide]: couldn't find it in this repository, so I searched and got [jsguide.html](https://google.github.io/styleguide/jsguide.html)
* [commit-message-format]: seems similar to [COMMIT_CONVENTION.md](https://github.com/discordx-ts/discordx/blob/main/.github/COMMIT_CONVENTION.md)
* [dev-doc], [individual-cla], [corporate-cla]: I cannot find a suitable URL, so linked their own heading temporary.
```md
[dev-doc]: #submit-pr
[individual-cla]: #cla
[corporate-cla]: #cla
```

I don't know what to do about them.

## Package

- discordx

## Additional Context

I'm new at contributing to the open-source GitHub repository.
if there is something that I missed, please notice me.
thanks.