### PR TITLE
refactor(di): added clearAllServices method for engine and updated DIService to act as bridge for engine only

### DIFF
--- a/packages/di/CHANGELOG.md
+++ b/packages/di/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @discordx/di
 
+## 3.3.0
+
+### Minor Changes
+
+- refactor: added clearAllServices method for engine and updated DIService to act as bridge for engine only
+
 ## 3.2.0
 
 ### Minor Changes

--- a/packages/di/examples/tsyringe/main.ts
+++ b/packages/di/examples/tsyringe/main.ts
@@ -25,5 +25,5 @@ export class Example {
 }
 
 DIService.engine = tsyringeDependencyRegistryEngine.setInjector(container);
-DIService.instance.addService(Example);
-DIService.instance.getService(Example);
+DIService.engine.addService(Example);
+DIService.engine.getService(Example);

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordx/di",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "private": false,
   "description": "dependency injection service with TSyringe support",
   "keywords": [

--- a/packages/di/src/index.ts
+++ b/packages/di/src/index.ts
@@ -25,48 +25,25 @@ export type InstanceOf<T> = T extends new (...args: unknown[]) => infer R
  * @category Internal
  */
 export class DIService {
-  private static _diEngineToUse: IDependencyRegistryEngine =
+  private static _engine: IDependencyRegistryEngine =
     defaultDependencyRegistryEngine;
 
-  private static _instance: DIService;
-
   static get engine(): IDependencyRegistryEngine {
-    return DIService._diEngineToUse;
+    return DIService._engine;
   }
 
   static set engine(engine: IDependencyRegistryEngine) {
-    DIService._diEngineToUse = engine;
-  }
-
-  static get instance(): DIService {
-    if (!this._instance) {
-      this._instance = new DIService();
-    }
-    return this._instance;
+    DIService._engine = engine;
   }
 
   /**
-   * Get all Discord service classes
-   * @returns {Set<unknown>}
+   * @deprecated use DIService.engine instead
    */
-  static get allServices(): Set<unknown> {
-    return DIService.engine.getAllServices();
+  static get instance(): IDependencyRegistryEngine {
+    return this.engine;
   }
 
-  /**
-   * Add a service from the IOC container.
-   * @param {T} classType - The type of service to add
-   */
-  addService<T>(classType: T): void {
-    DIService.engine.addService(classType);
-  }
-
-  /**
-   * Get a service from the IOC container
-   * @param {T} classType - the Class of the service to retrieve
-   * @returns {InstanceOf<T> | null} the instance of this service or null if there is no instance
-   */
-  getService<T>(classType: T): InstanceOf<T> | null {
-    return DIService.engine.getService(classType);
+  private constructor() {
+    // empty constructor
   }
 }

--- a/packages/di/src/logic/AbstractConfigurableDependencyInjector.ts
+++ b/packages/di/src/logic/AbstractConfigurableDependencyInjector.ts
@@ -22,6 +22,8 @@ export abstract class AbstractConfigurableDependencyInjector<I>
 
   public abstract addService<T>(classType: T): void;
 
+  public abstract clearAllServices(): void;
+
   public abstract getAllServices(): Set<unknown>;
 
   public abstract getService<T>(classType: T): InstanceOf<T> | null;

--- a/packages/di/src/logic/IDependencyRegistryEngine.ts
+++ b/packages/di/src/logic/IDependencyRegistryEngine.ts
@@ -11,6 +11,11 @@ export interface IDependencyRegistryEngine {
   addService<T>(classType: T): void;
 
   /**
+   * Clear all Discord service classes
+   */
+  clearAllServices(): void;
+
+  /**
    * Get all Discord service classes
    * @returns {Set<unknown>}
    */

--- a/packages/di/src/logic/impl/DefaultDependencyRegistryEngine.ts
+++ b/packages/di/src/logic/impl/DefaultDependencyRegistryEngine.ts
@@ -16,14 +16,18 @@ export class DefaultDependencyRegistryEngine
     return DefaultDependencyRegistryEngine._instance;
   }
 
-  public getAllServices(): Set<unknown> {
-    return new Set(this._services.values());
-  }
-
   public addService<T>(classType: T): void {
     const clazz = classType as unknown as new () => InstanceOf<T>;
     const instance = new clazz();
     this._services.set(clazz, instance);
+  }
+
+  public clearAllServices(): void {
+    this._services.clear();
+  }
+
+  public getAllServices(): Set<unknown> {
+    return new Set(this._services.values());
   }
 
   public getService<T>(classType: T): InstanceOf<T> {

--- a/packages/di/src/logic/impl/TsyringeDependencyRegistryEngine.ts
+++ b/packages/di/src/logic/impl/TsyringeDependencyRegistryEngine.ts
@@ -46,6 +46,13 @@ export class TsyringeDependencyRegistryEngine extends AbstractConfigurableDepend
     }
   }
 
+  public clearAllServices(): void {
+    if (!this.injector) {
+      throw new Error("Please set the container!");
+    }
+    this.injector.clearInstances();
+  }
+
   public getService<T>(classType: T): InstanceOf<T> | null {
     if (!this.injector) {
       throw new Error("Please set the container!");

--- a/packages/di/src/logic/impl/TypeDiDependencyRegistryEngine.ts
+++ b/packages/di/src/logic/impl/TypeDiDependencyRegistryEngine.ts
@@ -40,6 +40,13 @@ export class TypeDiDependencyRegistryEngine extends AbstractConfigurableDependen
     }
   }
 
+  public clearAllServices(): void {
+    if (!this.injector) {
+      throw new Error("Please set the Service!");
+    }
+    this.injector.reset();
+  }
+
   public setService(service: typeof Service): this {
     this.service = service;
     return this;


### PR DESCRIPTION
## Engines (A briefing)

They store singleton instances of class.

- Default: A simple `Map` for singleton classes.
- TSyringe
- TypeDI

## What's added?

A engine method, that allow cleanup for supported dependency engines.
