### PR TITLE
ci: use changesets changelog-github

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "discordx-ts/discordx" }
+  ],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test": "turbo run test"
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
     "@commitlint/cli": "^18.4.3",
     "@commitlint/config-angular": "^18.4.3",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Switches Changesets to use  [@changesets/changelog-github](https://github.com/changesets/changesets/tree/main/packages/changelog-github) which passes a lot more information retaining to GitHub to the CHANGELOGS and GitHub releases.

With and Without using changelog-github:
- [with](https://github.com/changesets/changesets/blob/main/packages/cli/CHANGELOG.md) vs [without](https://github.com/discordx-ts/discordx/blob/main/packages/discordx/CHANGELOG.md)
- [with](https://github.com/changesets/changesets/releases/tag/%40changesets%2Fcli%402.27.0) vs [without](https://github.com/discordx-ts/discordx/releases/tag/music-6.0.0)