### PR TITLE
docs: fix various broken links

### DIFF
--- a/docs/docs/discordx/decorators/command/slash-option.md
+++ b/docs/docs/discordx/decorators/command/slash-option.md
@@ -233,7 +233,7 @@ class Example {
 
 ## Autocompletion (Option's choices)
 
-You can use the [@SlashChoice](docs/discordx/decorators/command/slash-choice) decorator
+You can use the [@SlashChoice](./slash-choice) decorator
 
 ## Option order
 

--- a/docs/docs/discordx/decorators/general/bot.md
+++ b/docs/docs/discordx/decorators/general/bot.md
@@ -50,18 +50,18 @@ MetadataStorage.instance.build().then(() => {
 
 It either extends or overwrites data configured in below decorators, however, the order of decorators matters.
 
-[@ButtonComponent](docs/discordx/decorators/gui/button-component)
+[@ButtonComponent](../gui/button-component)
 
-[@SelectMenuComponent](docs/discordx/decorators/gui/select-menu-component)
+[@SelectMenuComponent](../gui/select-menu-component)
 
-[@ContextMenu](docs/discordx/decorators/gui/context-menu)
+[@ContextMenu](../gui/context-menu)
 
-[@Discord](docs/discordx/decorators/general/discord)
+[@Discord](./discord)
 
-[@On](docs/discordx/decorators/general/on)
+[@On](./on)
 
-[@Once](docs/discordx/decorators/general/once)
+[@Once](./once)
 
-[@SimpleCommand](docs/discordx/decorators/command/simple-command)
+[@SimpleCommand](../command/simple-command)
 
-[@Slash](docs/discordx/decorators/command/slash)
+[@Slash](../command/slash)

--- a/docs/docs/discordx/decorators/general/guard.md
+++ b/docs/docs/discordx/decorators/general/guard.md
@@ -250,18 +250,18 @@ Guard<Type = any, DataType = any>(
 
 It either extends or overwrites data configured in below decorators, however, the order of decorators matters.
 
-[@ButtonComponent](docs/discordx/decorators/gui/button-component)
+[@ButtonComponent](../gui/button-component)
 
-[@SelectMenuComponent](docs/discordx/decorators/gui/select-menu-component)
+[@SelectMenuComponent](../gui/select-menu-component)
 
-[@Discord](docs/discordx/decorators/general/discord)
+[@Discord](./discord)
 
-[@ModalComponent](docs/discordx/decorators/gui/modal-component)
+[@ModalComponent](../gui/modal-component)
 
-[@On](docs/discordx/decorators/general/on)
+[@On](./on)
 
-[@Once](docs/discordx/decorators/general/once)
+[@Once](./once)
 
-[@SimpleCommand](docs/discordx/decorators/command/simple-command)
+[@SimpleCommand](../command/simple-command)
 
-[@Slash](docs/discordx/decorators/command/slash)
+[@Slash](../command/slash)

--- a/docs/docs/discordx/decorators/general/guild.md
+++ b/docs/docs/discordx/decorators/general/guild.md
@@ -69,12 +69,12 @@ this._client = new Client({
 
 It either extends or overwrites data configured in below decorators, however, the order of decorators matters.
 
-[@ButtonComponent](docs/discordx/decorators/gui/button-component)
+[@ButtonComponent](../gui/button-component)
 
-[@SelectMenuComponent](docs/discordx/decorators/gui/select-menu-component)
+[@SelectMenuComponent](../gui/select-menu-component)
 
-[@Discord](docs/discordx/decorators/general/discord)
+[@Discord](./discord)
 
-[@SimpleCommand](docs/discordx/decorators/command/simple-command)
+[@SimpleCommand](../command/simple-command)
 
-[@Slash](docs/discordx/decorators/command/slash)
+[@Slash](../command/slash)

--- a/docs/docs/discordx/decorators/general/once.md
+++ b/docs/docs/discordx/decorators/general/once.md
@@ -26,7 +26,7 @@ You also receive other useful arguments after that:
 
 1. The event payload (`ArgsOf<"YOUR_EVENT">`)
 2. The `Client` instance
-3. The [guards](docs/discordx/decorators/general/guard) payload
+3. The [guards](./guard) payload
 
 > You should use JS destructuring for `ArgsOf<"YOUR_EVENT">` like in this example
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fix various links that result in `docs/discordx/*/*/*/docs/discordx/*/*/*` instead of `docs/discordx/*/*/*`