### PR TITLE
refactor(utilities): Use relative timestamps

### DIFF
--- a/.changeset/rare-birds-matter.md
+++ b/.changeset/rare-birds-matter.md
@@ -1,0 +1,5 @@
+---
+"@discordx/utilities": minor
+---
+
+use relative time in rate limit guard

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -153,14 +153,14 @@ class RateLimitExample {
   /**
    * Allow 3 command before rate limit of 30 seconds (from last message)
    */
-  @Slash({ name: "rate_limit_3" })
+  @Slash({ name: "rate_limit_2" })
   @Guard(
     RateLimit(TIME_UNIT.seconds, 30, {
       message: "Please wait `30` seconds!",
       rateValue: 3,
     }),
   )
-  rateLimit3(interaction: CommandInteraction): void {
+  rateLimit2(interaction: CommandInteraction): void {
     interaction.reply("It worked!");
   }
 

--- a/packages/utilities/examples/guards/commands/PermissionGuards.ts
+++ b/packages/utilities/examples/guards/commands/PermissionGuards.ts
@@ -12,8 +12,8 @@ export class PermissionGuards {
    * @param interaction
    */
   @Slash({
-    description: "permission_ban_members",
-    name: "permission_ban_members",
+    description: "permission_ban_members_1",
+    name: "permission_ban_members_1",
   })
   @Guard(PermissionGuard(["BanMembers"]))
   banMembers1(interaction: CommandInteraction): void {
@@ -26,8 +26,8 @@ export class PermissionGuards {
    * @param interaction
    */
   @Slash({
-    description: "permission_ban_members",
-    name: "permission_ban_members",
+    description: "permission_ban_members_2",
+    name: "permission_ban_members_2",
   })
   @Guard(
     PermissionGuard(["BanMembers"], {
@@ -45,8 +45,8 @@ export class PermissionGuards {
    * @param interaction
    */
   @Slash({
-    description: "permission_ban_members",
-    name: "permission_ban_members",
+    description: "permission_ban_members_3",
+    name: "permission_ban_members_3",
   })
   @Guard(
     PermissionGuard(PermissionGuards.resolvePermission, {

--- a/packages/utilities/examples/guards/commands/RateLimit.ts
+++ b/packages/utilities/examples/guards/commands/RateLimit.ts
@@ -54,9 +54,9 @@ export class RateLimitExample {
    */
   @Slash({ description: "rate_limit_4", name: "rate_limit_4" })
   @Guard(
-    RateLimit(TIME_UNIT.seconds, 30, {
+    RateLimit(TIME_UNIT.minutes, 5, {
       message:
-        "Slow Down, please try at {until}, if you do not try at {until} then this command will not work",
+        "Slow Down, please try in {time}, if you do try in {time} then this command will not work",
     }),
   )
   rateLimit4(interaction: CommandInteraction): void {
@@ -86,7 +86,7 @@ export class RateLimitExample {
     return Promise.resolve(
       `${
         interaction.commandName
-      } will be available again at {until}, this is in ${Math.round(
+      } will be available again in {time}, this is in ${Math.round(
         timeLeft / 1000,
       )} seconds`,
     );

--- a/packages/utilities/examples/guards/commands/RateLimit.ts
+++ b/packages/utilities/examples/guards/commands/RateLimit.ts
@@ -55,8 +55,7 @@ export class RateLimitExample {
   @Slash({ description: "rate_limit_4", name: "rate_limit_4" })
   @Guard(
     RateLimit(TIME_UNIT.minutes, 5, {
-      message:
-        "Slow Down, please try in {time}, if you do try in {time} then this command will not work",
+      message: "Slow Down, please try in {time}",
     }),
   )
   rateLimit4(interaction: CommandInteraction): void {

--- a/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
+++ b/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
@@ -30,8 +30,7 @@ export function RateLimit<T extends CommandInteraction | SimpleCommandMessage>(
 ): GuardFunction<T> {
   const rateValue = options?.rateValue ?? 1;
   const rateMessage =
-    options?.message ??
-    "message being rate limited!, please try again {until}";
+    options?.message ?? "message being rate limited!, please try again {until}";
 
   function convertToMillisecond(timeValue: number, unit: TIME_UNIT): number {
     switch (unit) {

--- a/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
+++ b/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
@@ -5,6 +5,7 @@ import type {
 import type { GuardFunction } from "discordx";
 import { SimpleCommandMessage } from "discordx";
 
+import { dayjs } from "../../useful/time-format.js";
 import type { RateLimitOption } from "./index.js";
 import { TIME_UNIT, TimedSet } from "./index.js";
 import { TimeOutEntry } from "./logic/index.js";
@@ -23,14 +24,15 @@ export function RateLimit<T extends CommandInteraction | SimpleCommandMessage>(
   timeout: TIME_UNIT,
   value: number,
   options: RateLimitOption<T> = {
-    ephemeral: false,
-    message: "message being rate limited!, please try again {until}",
+    ephemeral: true,
+    message: "message being rate limited!, please try again in {time}",
     rateValue: 1,
   },
 ): GuardFunction<T> {
   const rateValue = options?.rateValue ?? 1;
   const rateMessage =
-    options?.message ?? "message being rate limited!, please try again {until}";
+    options?.message ??
+    "message being rate limited!, please try again in {time}";
 
   function convertToMillisecond(timeValue: number, unit: TIME_UNIT): number {
     switch (unit) {
@@ -95,7 +97,7 @@ export function RateLimit<T extends CommandInteraction | SimpleCommandMessage>(
     if (arg instanceof SimpleCommandMessage) {
       await arg?.message.reply(msg);
     } else {
-      return replyOrFollowUp(arg, msg, options?.ephemeral ?? false);
+      return replyOrFollowUp(arg, msg, options?.ephemeral ?? true);
     }
   }
 
@@ -118,23 +120,35 @@ export function RateLimit<T extends CommandInteraction | SimpleCommandMessage>(
     let fromArray = getFromArray(memberId, guildId);
     if (fromArray) {
       fromArray.incrementCallCount();
-      const timeLeft = getTimeLeft(fromArray);
-      const whenWillExecute = Date.now() + timeLeft;
       if (fromArray.hasLimitReached()) {
-        const messageString =
+        /**
+         * Get time left
+         */
+        const timeLeft = getTimeLeft(fromArray);
+
+        /**
+         * Get message string
+         */
+        let messageString =
           typeof rateMessage === "function"
             ? await rateMessage(arg, timeLeft)
             : rateMessage;
 
-        if (messageString.includes("{until}")) {
-          return post(
-            arg,
-            messageString.replaceAll(
-              "{until}",
-              `<t:${Math.round(whenWillExecute / 1000)}:R>`,
-            ),
-          );
-        }
+        /**
+         * Get static relative time text
+         */
+        const timeText = dayjs().add(timeLeft, "milliseconds").fromNow(true);
+
+        /**
+         * Format placeholders in message
+         */
+        ["{until}", "{time}"].forEach((text) => {
+          messageString = messageString.replaceAll(text, timeText);
+        });
+
+        /**
+         * Send message and terminate execution
+         */
         return post(arg, messageString);
       }
 

--- a/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
+++ b/packages/utilities/src/guards/Rate Limiter/RateLimit.ts
@@ -24,14 +24,14 @@ export function RateLimit<T extends CommandInteraction | SimpleCommandMessage>(
   value: number,
   options: RateLimitOption<T> = {
     ephemeral: false,
-    message: "message being rate limited!, please try again at {until}",
+    message: "message being rate limited!, please try again {until}",
     rateValue: 1,
   },
 ): GuardFunction<T> {
   const rateValue = options?.rateValue ?? 1;
   const rateMessage =
     options?.message ??
-    "message being rate limited!, please try again at {until}";
+    "message being rate limited!, please try again {until}";
 
   function convertToMillisecond(timeValue: number, unit: TIME_UNIT): number {
     switch (unit) {
@@ -132,7 +132,7 @@ export function RateLimit<T extends CommandInteraction | SimpleCommandMessage>(
             arg,
             messageString.replaceAll(
               "{until}",
-              `<t:${Math.round(whenWillExecute / 1000)}:T>`,
+              `<t:${Math.round(whenWillExecute / 1000)}:R>`,
             ),
           );
         }

--- a/packages/utilities/src/guards/Rate Limiter/types/common.ts
+++ b/packages/utilities/src/guards/Rate Limiter/types/common.ts
@@ -10,8 +10,8 @@ export type RateLimitOption<
   ephemeral?: boolean;
   /**
    * the message to post when a command is called when the
-   * user is in rate limit, defaults = "message being rate limited!, please try again at {until}".
-   * use the placeholder {until} in your string to get the time you can next call it `<t:epoch:T>`
+   * user is in rate limit, defaults = "message being rate limited!, please try again at {time}".
+   * use the placeholder {time} in your string to get the time you can next call it `<t:epoch:T>`
    * If a function is supplied, it will pass both the interaction and how many milliseconds are left until the rate limit is over
    */
   message?: ((interaction: T, timeLeft: number) => Awaitable<string>) | string;

--- a/packages/utilities/src/useful/time-format.ts
+++ b/packages/utilities/src/useful/time-format.ts
@@ -1,7 +1,7 @@
 import myDayJS from "dayjs";
-import customParseFormat from "dayjs/plugin/customParseFormat";
-import objectSupport from "dayjs/plugin/objectSupport";
-import relativeTime from "dayjs/plugin/relativeTime";
+import customParseFormat from "dayjs/plugin/customParseFormat.js";
+import objectSupport from "dayjs/plugin/objectSupport.js";
+import relativeTime from "dayjs/plugin/relativeTime.js";
 
 /**
  * Extend dayjs with relativeTime plugin


### PR DESCRIPTION
I think a much more user-friendly option is to use relative timestamps, it makes more sense to say you can use the command in 5 seconds, or in 6 hours, instead of telling the user that you can use it at 6:42 PM.

On the other hand I'm not sure if this change is to be merged as is, it's meant to start a discussion:
* Does the noun `until` still make any sense here after the change?
* Maybe we could add another substitution like `{time}` or `{duration}` and keep `{until}` as is, this will preserve backward compatibility with existing code while giving an option to use this relative notation for those who desires it.
* If we go with that, I'd still choose the relative notation to be the default option as it makes more sense.
* I would also choose to refactor the default reply message as it kind of feels unprofessional to me.

Off topic but I would also propose for making the `ephemeral` option be `true` by default, it's one of the best features of slash commands and as slash commands are meant to reduce user mistakes it also makes sense to spit out rate limit errors and similar in an ephemeral reply rather than contributing to useless bot command spam, at least that's my opinion that all errors and embarrassing mistakes remain an ephemeral reply only sending the actual results to the world. Obviously I can just wrap the guard into a custom function and set it to true as the default for my own bot but I'd like to hear the possibility of it being the default here?