### PR TITLE
feat(utilities): time format

### DIFF
--- a/.changeset/real-phones-sit.md
+++ b/.changeset/real-phones-sit.md
@@ -1,0 +1,5 @@
+---
+"@discordx/utilities": minor
+---
+
+Introduced TimeFormat - an simple method for formatting time into a Discord timestamp.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5865,6 +5865,11 @@
       "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
       "dev": true
     },
+    "node_modules/dayjs": {
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -15806,6 +15811,7 @@
       }
     },
     "packages/changelog": {
+      "name": "@discordx/changelog",
       "version": "2.12.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15874,6 +15880,7 @@
       }
     },
     "packages/di": {
+      "name": "@discordx/di",
       "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15920,6 +15927,7 @@
       }
     },
     "packages/importer": {
+      "name": "@discordx/importer",
       "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15933,6 +15941,7 @@
       }
     },
     "packages/internal": {
+      "name": "@discordx/internal",
       "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15948,6 +15957,7 @@
       }
     },
     "packages/koa": {
+      "name": "@discordx/koa",
       "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15974,6 +15984,7 @@
       }
     },
     "packages/lava-player": {
+      "name": "@discordx/lava-player",
       "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -15995,6 +16006,7 @@
       }
     },
     "packages/lava-queue": {
+      "name": "@discordx/lava-queue",
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16021,6 +16033,7 @@
       }
     },
     "packages/music": {
+      "name": "@discordx/music",
       "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16054,6 +16067,7 @@
       }
     },
     "packages/pagination": {
+      "name": "@discordx/pagination",
       "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16077,6 +16091,7 @@
       }
     },
     "packages/socket.io": {
+      "name": "@discordx/socket.io",
       "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
@@ -16102,9 +16117,11 @@
       }
     },
     "packages/utilities": {
+      "name": "@discordx/utilities",
       "version": "6.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "dayjs": "^1.11.10",
         "tslib": "^2.6.2"
       },
       "devDependencies": {

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -48,6 +48,7 @@
   - [PermissionGuard](#permissionguard)
 - [Useful](#-useful)
   - [EnumChoice](#enumchoice)
+  - [TimeFormat](#timeformat)
 
 # 📖 Introduction
 
@@ -271,6 +272,48 @@ enum RPS {
 }
 
 @SlashChoice(...EnumChoice(RPS))
+```
+
+## TimeFormat
+
+### Discord Timestamps
+
+Discord timestamps can be useful for specifying a date/time across multiple users time zones. They work with the Unix Timestamp format and can be posted by regular users as well as bots and applications.
+
+[The Epoch Unix Time Stamp Converter](https://www.unixtimestamp.com/) is a good way to quickly generate a timestamp. For the examples below I will be using the Time Stamp of `1543392060`, which represents `November 28th, 2018` at `09:01:00` hours for my local time zone (GMT+0100 Central European Standard Time).
+
+### Formatting
+
+| Style                | Output             | Output (12-hour clock)               | Output (24-hour clock)            | Syntax                          |
+| -------------------- | ------------------ | ------------------------------------ | --------------------------------- | ------------------------------- |
+| Default              | `<t:1543392060>`   | November 28, 2018 9:01 AM            | 28 November 2018 09:01            | `TimeFormat.Default`            |
+| Short Time           | `<t:1543392060:t>` | 9:01 AM                              | 09:01                             | `TimeFormat.ShortTime`          |
+| Long Time            | `<t:1543392060:T>` | 9:01:00 AM                           | 09:01:00                          | `TimeFormat.LongTime`           |
+| Short Date           | `<t:1543392060:d>` | 11/28/2018                           | 28/11/2018                        | `TimeFormat.ShortDate`          |
+| Long Date            | `<t:1543392060:D>` | November 28, 2018                    | 28 November 2018                  | `TimeFormat.LongDate`           |
+| Short Date/Time      | `<t:1543392060:f>` | November 28, 2018 9:01 AM            | 28 November 2018 09:01            | `TimeFormat.ShortDateTime`      |
+| Long Date/Time       | `<t:1543392060:F>` | Wednesday, November 28, 2018 9:01 AM | Wednesday, 28 November 2018 09:01 | `TimeFormat.LongDateTime`       |
+| Relative Time        | `<t:1543392060:R>` | 3 years ago                          | 3 years ago                       | `TimeFormat.RelativeTime`       |
+| Static Relative Time | `3 years ago`      | 3 years ago                          | 3 years ago                       | `TimeFormat.StaticRelativeTime` |
+
+Whether your output is 12-hour or 24-hour depends on your Discord language setting. For example, if you have your Discord language set to `English, US 🇺🇸`, you will get a 12-hour output. If your Discord language is set to `English, UK 🇬🇧`, you will get a 24-hour output.
+
+Source: https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa
+
+### Example
+
+```ts
+import { dayjs, TimeFormat } from "@discordx/utilities";
+
+const message = `I will be there in ${TimeFormat.StaticRelativeTime("31/12/2025", false)}`;
+const message = `I will be there by ${TimeFormat.LongDate(
+  dayjs({
+    day: 31,
+    month: 12,
+    year: 2025,
+  }),
+  false,
+)}`;
 ```
 
 # 📜 Documentation

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -284,17 +284,17 @@ Discord timestamps can be useful for specifying a date/time across multiple user
 
 ### Formatting
 
-| Style                | Output             | Output (12-hour clock)               | Output (24-hour clock)            | Syntax                          |
-| -------------------- | ------------------ | ------------------------------------ | --------------------------------- | ------------------------------- |
-| Default              | `<t:1543392060>`   | November 28, 2018 9:01 AM            | 28 November 2018 09:01            | `TimeFormat.Default`            |
-| Short Time           | `<t:1543392060:t>` | 9:01 AM                              | 09:01                             | `TimeFormat.ShortTime`          |
-| Long Time            | `<t:1543392060:T>` | 9:01:00 AM                           | 09:01:00                          | `TimeFormat.LongTime`           |
-| Short Date           | `<t:1543392060:d>` | 11/28/2018                           | 28/11/2018                        | `TimeFormat.ShortDate`          |
-| Long Date            | `<t:1543392060:D>` | November 28, 2018                    | 28 November 2018                  | `TimeFormat.LongDate`           |
-| Short Date/Time      | `<t:1543392060:f>` | November 28, 2018 9:01 AM            | 28 November 2018 09:01            | `TimeFormat.ShortDateTime`      |
-| Long Date/Time       | `<t:1543392060:F>` | Wednesday, November 28, 2018 9:01 AM | Wednesday, 28 November 2018 09:01 | `TimeFormat.LongDateTime`       |
-| Relative Time        | `<t:1543392060:R>` | 3 years ago                          | 3 years ago                       | `TimeFormat.RelativeTime`       |
-| Static Relative Time | `3 years ago`      | 3 years ago                          | 3 years ago                       | `TimeFormat.StaticRelativeTime` |
+| Syntax                        | Output             | Output (12-hour clock)               | Output (24-hour clock)            |
+| ----------------------------- | ------------------ | ------------------------------------ | --------------------------------- |
+| TimeFormat.Default            | `<t:1543392060>`   | November 28, 2018 9:01 AM            | 28 November 2018 09:01            |
+| TimeFormat.ShortTime          | `<t:1543392060:t>` | 9:01 AM                              | 09:01                             |
+| TimeFormat.LongTime           | `<t:1543392060:T>` | 9:01:00 AM                           | 09:01:00                          |
+| TimeFormat.ShortDate          | `<t:1543392060:d>` | 11/28/2018                           | 28/11/2018                        |
+| TimeFormat.LongDate           | `<t:1543392060:D>` | November 28, 2018                    | 28 November 2018                  |
+| TimeFormat.ShortDateTime      | `<t:1543392060:f>` | November 28, 2018 9:01 AM            | 28 November 2018 09:01            |
+| TimeFormat.LongDateTime       | `<t:1543392060:F>` | Wednesday, November 28, 2018 9:01 AM | Wednesday, 28 November 2018 09:01 |
+| TimeFormat.RelativeTime       | `<t:1543392060:R>` | 3 years ago                          | 3 years ago                       |
+| TimeFormat.StaticRelativeTime | `3 years ago`      | 3 years ago                          | 3 years ago                       |
 
 Whether your output is 12-hour or 24-hour depends on your Discord language setting. For example, if you have your Discord language set to `English, US 🇺🇸`, you will get a 12-hour output. If your Discord language is set to `English, UK 🇬🇧`, you will get a 24-hour output.
 

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -43,6 +43,7 @@
     "build:typedoc": "npx typedoc src/index.ts --out ../../docs/static/api/utilities"
   },
   "dependencies": {
+    "dayjs": "^1.11.10",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/utilities/src/useful/index.ts
+++ b/packages/utilities/src/useful/index.ts
@@ -1,1 +1,2 @@
 export * from "./enum.js";
+export * from "./time-format.js";

--- a/packages/utilities/src/useful/time-format.ts
+++ b/packages/utilities/src/useful/time-format.ts
@@ -1,0 +1,120 @@
+import myDayJS from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import objectSupport from "dayjs/plugin/objectSupport";
+import relativeTime from "dayjs/plugin/relativeTime";
+
+/**
+ * Extend dayjs with relativeTime plugin
+ */
+myDayJS.extend(relativeTime);
+
+/**
+ * Extend myDayJS with custom date parser
+ */
+myDayJS.extend(customParseFormat);
+
+/**
+ * Extend myDayJS with object support
+ */
+myDayJS.extend(objectSupport);
+
+/**
+ * Export dayjs
+ */
+export const dayjs = myDayJS;
+
+/**
+ * Type for time
+ */
+export type Time = myDayJS.ConfigType;
+
+/**
+ * TimeFormat
+ *
+ * Format time to various discord time format.
+ */
+export const TimeFormat = {
+  /**
+   * Get the formatted date according to the string of tokens passed in.
+   *
+   * To escape characters, wrap them in square brackets (e.g. [MM]).
+   * ```
+   * TimeFormat.format() // => current date in ISO8601, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
+   * TimeFormat.format('2019-01-25', '[YYYYescape] YYYY-MM-DDTHH:mm:ssZ[Z]') // 'YYYYescape 2019-01-25T00:00:00-02:00Z'
+   * TimeFormat.format('2019-01-25', 'DD/MM/YYYY') // '25/01/2019'
+   * ```
+   * Docs: https://day.js.org/docs/en/display/format
+   */
+  Custom: (time: Time, template?: string | undefined): string =>
+    dayjs(time).format(template),
+
+  /**
+   * 12 Hour Clock: November 28, 2018 9:01 AM
+   *
+   * 24 Hour Clock: 28 November 2018 09:01
+   */
+  Default: (time: Time): string => `<t:${dayjs(time).unix()}>`,
+
+  /**
+   * 12 Hour Clock: November 28, 2018
+   *
+   * 24 Hour Clock: 28 November 2018
+   */
+  LongDate: (time: Time): string => `<t:${dayjs(time).unix()}:D>`,
+
+  /**
+   * 12 Hour Clock: Wednesday, November 28, 2018 9:01 AM
+   *
+   * 24 Hour Clock: Wednesday, 28 November 2018 09:01
+   */
+  LongDateTime: (time: Time): string => `<t:${dayjs(time).unix()}:F>`,
+
+  /**
+   * 12 Hour Clock: 9:01:00 AM
+   *
+   * 24 Hour Clock: 09:01:00
+   */
+  LongTime: (time: Time): string => `<t:${dayjs(time, "").unix()}:T>`,
+
+  /**
+   * The Discord relative time updates every second.
+   *
+   * 12 Hour Clock: 3 years ago
+   *
+   * 24 Hour Clock: 3 years ago
+   */
+  RelativeTime: (time: Time): string => `<t:${dayjs(time).unix()}:R>`,
+
+  /**
+   * 12 Hour Clock: 11/28/2018
+   *
+   * 24 Hour Clock: 28/11/2018
+   */
+  ShortDate: (time: Time): string => `<t:${dayjs(time).unix()}:d>`,
+
+  /**
+   * 12 Hour Clock: November 28, 2018 9:01 AM
+   *
+   * 24 Hour Clock: 28 November 2018 09:01
+   */
+  ShortDateTime: (time: Time): string => `<t:${dayjs(time).unix()}:f>`,
+
+  /**
+   * 12 Hour Clock: 9:01 AM
+   *
+   * 24 Hour Clock: 09:01
+   */
+  ShortTime: (time: Time): string => `<t:${dayjs(time).unix()}:t>`,
+
+  /**
+   * Unlike Discord relative time which updates every second, this remain static.
+   *
+   * 12 Hour Clock: 3 years ago
+   *
+   * 24 Hour Clock: 3 years ago
+   */
+  StaticRelativeTime: (
+    time: Time,
+    withoutSuffix?: boolean | undefined,
+  ): string => dayjs(time).fromNow(withoutSuffix),
+};

--- a/packages/utilities/src/useful/time-format.ts
+++ b/packages/utilities/src/useful/time-format.ts
@@ -35,20 +35,6 @@ export type Time = myDayJS.ConfigType;
  */
 export const TimeFormat = {
   /**
-   * Get the formatted date according to the string of tokens passed in.
-   *
-   * To escape characters, wrap them in square brackets (e.g. [MM]).
-   * ```
-   * TimeFormat.format() // => current date in ISO8601, without fraction seconds e.g. '2020-04-02T08:02:17-05:00'
-   * TimeFormat.format('2019-01-25', '[YYYYescape] YYYY-MM-DDTHH:mm:ssZ[Z]') // 'YYYYescape 2019-01-25T00:00:00-02:00Z'
-   * TimeFormat.format('2019-01-25', 'DD/MM/YYYY') // '25/01/2019'
-   * ```
-   * Docs: https://day.js.org/docs/en/display/format
-   */
-  Custom: (time: Time, template?: string | undefined): string =>
-    dayjs(time).format(template),
-
-  /**
    * 12 Hour Clock: November 28, 2018 9:01 AM
    *
    * 24 Hour Clock: 28 November 2018 09:01


### PR DESCRIPTION
## TimeFormat

### Discord Timestamps

Discord timestamps can be useful for specifying a date/time across multiple users time zones. They work with the Unix Timestamp format and can be posted by regular users as well as bots and applications.

[The Epoch Unix Time Stamp Converter](https://www.unixtimestamp.com/) is a good way to quickly generate a timestamp. For the examples below I will be using the Time Stamp of `1543392060`, which represents `November 28th, 2018` at `09:01:00` hours for my local time zone (GMT+0100 Central European Standard Time).

### Formatting

| Syntax                        | Output             | Output (12-hour clock)               | Output (24-hour clock)            |
| ----------------------------- | ------------------ | ------------------------------------ | --------------------------------- |
| TimeFormat.Default            | `<t:1543392060>`   | November 28, 2018 9:01 AM            | 28 November 2018 09:01            |
| TimeFormat.ShortTime          | `<t:1543392060:t>` | 9:01 AM                              | 09:01                             |
| TimeFormat.LongTime           | `<t:1543392060:T>` | 9:01:00 AM                           | 09:01:00                          |
| TimeFormat.ShortDate          | `<t:1543392060:d>` | 11/28/2018                           | 28/11/2018                        |
| TimeFormat.LongDate           | `<t:1543392060:D>` | November 28, 2018                    | 28 November 2018                  |
| TimeFormat.ShortDateTime      | `<t:1543392060:f>` | November 28, 2018 9:01 AM            | 28 November 2018 09:01            |
| TimeFormat.LongDateTime       | `<t:1543392060:F>` | Wednesday, November 28, 2018 9:01 AM | Wednesday, 28 November 2018 09:01 |
| TimeFormat.RelativeTime       | `<t:1543392060:R>` | 3 years ago                          | 3 years ago                       |
| TimeFormat.StaticRelativeTime | `3 years ago`      | 3 years ago                          | 3 years ago                       |

Whether your output is 12-hour or 24-hour depends on your Discord language setting. For example, if you have your Discord language set to `English, US 🇺🇸`, you will get a 12-hour output. If your Discord language is set to `English, UK 🇬🇧`, you will get a 24-hour output.

Source: https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa

### Example

```ts
import { dayjs, TimeFormat } from "@discordx/utilities";

const message = `I will be there in ${TimeFormat.StaticRelativeTime("31/12/2025", false)}`;
const message = `I will be there by ${TimeFormat.LongDate(
  dayjs({
    day: 31,
    month: 12,
    year: 2025,
  }),
  false,
)}`;
```