### PR TITLE
refactor(discordx): discordjs builders support

### DIFF
--- a/docs/docs/discordx/decorators/command/slash-option.md
+++ b/docs/docs/discordx/decorators/command/slash-option.md
@@ -44,6 +44,38 @@ class Example {
 }
 ```
 
+## Create option using discord.js builders
+
+```ts
+import {
+  SlashCommandBuilder,
+  SlashCommandMentionableOption,
+  User,
+  type CommandInteraction,
+} from "discord.js";
+import { Discord, Slash, SlashOption } from "discordx";
+
+const cmd = new SlashCommandBuilder()
+  .setName("hello")
+  .setDescription("Say hello!");
+
+const user_option = new SlashCommandMentionableOption()
+  .setName("user")
+  .setDescription("Mention user to say hello to.")
+  .setRequired(true);
+
+@Discord()
+export class Example {
+  @Slash(cmd)
+  async hello(
+    @SlashOption(user_option) user: User,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    await interaction.reply(`:wave: ${user}`);
+  }
+}
+```
+
 ## Transformer
 
 Act as middleware for your parameters. Take a look at the following example to see how useful it is.
@@ -81,13 +113,15 @@ function DocumentTransformer(
 export class Example {
   @Slash({ description: "Save input into database", name: "save-input" })
   async withTransformer(
-    @SlashOption({
-      description: "input",
-      name: "input",
-      required: true,
-      transformer: DocumentTransformer,
-      type: ApplicationCommandOptionType.String,
-    })
+    @SlashOption(
+      {
+        description: "input",
+        name: "input",
+        required: true,
+        type: ApplicationCommandOptionType.String,
+      },
+      DocumentTransformer,
+    )
     doc: Document,
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15012,7 +15012,7 @@
       }
     },
     "packages/discordx": {
-      "version": "11.11.3",
+      "version": "11.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordx/di": "^3.3.2",
@@ -15164,7 +15164,7 @@
       },
       "devDependencies": {
         "discord.js": "^14.15.3",
-        "discordx": "^11.11.1",
+        "discordx": "^11.12.0",
         "ts-node": "^10.9.2"
       },
       "peerDependencies": {
@@ -15205,7 +15205,7 @@
         "@discordx/importer": "^1.3.1",
         "@discordx/pagination": "^3.5.4",
         "discord.js": "^14.15.3",
-        "discordx": "^11.11.1",
+        "discordx": "^11.12.0",
         "typescript": "5.4.5"
       },
       "engines": {

--- a/packages/discordx/CHANGELOG.md
+++ b/packages/discordx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # discordx
 
+## 11.12.0
+
+### Minor Changes
+
+- added support for slash command builder
+
 ## 11.11.3
 
 ### Patch Changes

--- a/packages/discordx/examples/builders/commands/autocomplete.ts
+++ b/packages/discordx/examples/builders/commands/autocomplete.ts
@@ -1,0 +1,41 @@
+/*
+ * -------------------------------------------------------------------------------------------------------
+ * Copyright (c) Vijay Meena <vijayymmeena@gmail.com> (https://github.com/samarmeena). All rights reserved.
+ * Licensed under the Apache License. See License.txt in the project root for license information.
+ * -------------------------------------------------------------------------------------------------------
+ */
+import {
+  AutocompleteInteraction,
+  SlashCommandBuilder,
+  SlashCommandStringOption,
+  type CommandInteraction,
+} from "discord.js";
+import { Discord, Slash, SlashOption } from "discordx";
+
+const cmd = new SlashCommandBuilder()
+  .setName("planet-auto")
+  .setDescription("Select a planet");
+
+const planet_option = new SlashCommandStringOption()
+  .setName("planet")
+  .setDescription("Choose a planet")
+  .setRequired(true)
+  .setAutocomplete(true);
+
+@Discord()
+export class Example {
+  @Slash(cmd)
+  async hello(
+    @SlashOption(planet_option) planet: string,
+    interaction: CommandInteraction | AutocompleteInteraction,
+  ): Promise<void> {
+    if (interaction.isAutocomplete()) {
+      interaction.respond([
+        { name: "Earth", value: "Earth" },
+        { name: "Mars", value: "Mars" },
+      ]);
+    } else {
+      await interaction.reply(`:rocket: going to ${planet}`);
+    }
+  }
+}

--- a/packages/discordx/examples/builders/commands/choice.ts
+++ b/packages/discordx/examples/builders/commands/choice.ts
@@ -1,0 +1,36 @@
+/*
+ * -------------------------------------------------------------------------------------------------------
+ * Copyright (c) Vijay Meena <vijayymmeena@gmail.com> (https://github.com/samarmeena). All rights reserved.
+ * Licensed under the Apache License. See License.txt in the project root for license information.
+ * -------------------------------------------------------------------------------------------------------
+ */
+import {
+  SlashCommandBuilder,
+  SlashCommandStringOption,
+  type CommandInteraction,
+} from "discord.js";
+import { Discord, Slash, SlashOption } from "discordx";
+
+const cmd = new SlashCommandBuilder()
+  .setName("planet")
+  .setDescription("Select a planet");
+
+const planet_option = new SlashCommandStringOption()
+  .setName("planet")
+  .setDescription("Choose a planet")
+  .setRequired(true)
+  .addChoices([
+    { name: "Earth", value: "Earth" },
+    { name: "Mars", value: "Mars" },
+  ]);
+
+@Discord()
+export class Example {
+  @Slash(cmd)
+  async hello(
+    @SlashOption(planet_option) planet: string,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    await interaction.reply(`:rocket: going to ${planet}`);
+  }
+}

--- a/packages/discordx/examples/builders/commands/hello.ts
+++ b/packages/discordx/examples/builders/commands/hello.ts
@@ -1,0 +1,33 @@
+/*
+ * -------------------------------------------------------------------------------------------------------
+ * Copyright (c) Vijay Meena <vijayymmeena@gmail.com> (https://github.com/samarmeena). All rights reserved.
+ * Licensed under the Apache License. See License.txt in the project root for license information.
+ * -------------------------------------------------------------------------------------------------------
+ */
+import {
+  SlashCommandBuilder,
+  SlashCommandMentionableOption,
+  User,
+  type CommandInteraction,
+} from "discord.js";
+import { Discord, Slash, SlashOption } from "discordx";
+
+const cmd = new SlashCommandBuilder()
+  .setName("hello")
+  .setDescription("Say hello!");
+
+const user_option = new SlashCommandMentionableOption()
+  .setName("user")
+  .setDescription("Mention user to say hello to.")
+  .setRequired(true);
+
+@Discord()
+export class Example {
+  @Slash(cmd)
+  async hello(
+    @SlashOption(user_option) user: User,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    await interaction.reply(`:wave: ${user}`);
+  }
+}

--- a/packages/discordx/examples/builders/commands/ping.ts
+++ b/packages/discordx/examples/builders/commands/ping.ts
@@ -1,0 +1,20 @@
+/*
+ * -------------------------------------------------------------------------------------------------------
+ * Copyright (c) Vijay Meena <vijayymmeena@gmail.com> (https://github.com/samarmeena). All rights reserved.
+ * Licensed under the Apache License. See License.txt in the project root for license information.
+ * -------------------------------------------------------------------------------------------------------
+ */
+import { SlashCommandBuilder, type CommandInteraction } from "discord.js";
+import { Discord, Slash } from "discordx";
+
+const cmd = new SlashCommandBuilder()
+  .setName("ping")
+  .setDescription("Reply with pong!");
+
+@Discord()
+export class Example {
+  @Slash(cmd)
+  async ping(interaction: CommandInteraction): Promise<void> {
+    await interaction.reply("Pong");
+  }
+}

--- a/packages/discordx/examples/builders/main.ts
+++ b/packages/discordx/examples/builders/main.ts
@@ -1,0 +1,55 @@
+/*
+ * -------------------------------------------------------------------------------------------------------
+ * Copyright (c) Vijay Meena <vijayymmeena@gmail.com> (https://github.com/samarmeena). All rights reserved.
+ * Licensed under the Apache License. See License.txt in the project root for license information.
+ * -------------------------------------------------------------------------------------------------------
+ */
+import { dirname, importx } from "@discordx/importer";
+import { IntentsBitField } from "discord.js";
+import { Client } from "discordx";
+
+export class Main {
+  private static _client: Client;
+
+  static get Client(): Client {
+    return this._client;
+  }
+
+  static async start(): Promise<void> {
+    this._client = new Client({
+      // botGuilds: [(client) => client.guilds.cache.map((guild) => guild.id)],
+      intents: [
+        IntentsBitField.Flags.Guilds,
+        IntentsBitField.Flags.GuildMessages,
+        IntentsBitField.Flags.GuildMembers,
+      ],
+      silent: false,
+    });
+
+    this._client.once("ready", () => {
+      // An example of how guild commands can be cleared
+      //
+      // await this._client.clearApplicationCommands(
+      //   ...this._client.guilds.cache.map((guild) => guild.id)
+      // );
+
+      void this._client.initApplicationCommands();
+
+      console.log(">> Bot started");
+    });
+
+    this._client.on("interactionCreate", (interaction) => {
+      this._client.executeInteraction(interaction);
+    });
+
+    await importx(`${dirname(import.meta.url)}/commands/**/*.{js,ts}`);
+
+    // let's start the bot
+    if (!process.env.BOT_TOKEN) {
+      throw Error("Could not find BOT_TOKEN in your environment");
+    }
+    await this._client.login(process.env.BOT_TOKEN);
+  }
+}
+
+void Main.start();

--- a/packages/discordx/examples/builders/tsconfig.json
+++ b/packages/discordx/examples/builders/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "strict": true,
+    "noImplicitAny": true,
+    "outDir": "dist",
+    "emitDecoratorMetadata": false,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules", "tests", "examples"]
+}

--- a/packages/discordx/examples/slash/commands/transformer.ts
+++ b/packages/discordx/examples/slash/commands/transformer.ts
@@ -40,13 +40,15 @@ function DocumentTransformer(
 export class Example {
   @Slash({ description: "Save input into database", name: "save-input" })
   async withTransformer(
-    @SlashOption({
-      description: "input",
-      name: "input",
-      required: true,
-      transformer: DocumentTransformer,
-      type: ApplicationCommandOptionType.String,
-    })
+    @SlashOption(
+      {
+        description: "input",
+        name: "input",
+        required: true,
+        type: ApplicationCommandOptionType.String,
+      },
+      DocumentTransformer,
+    )
     doc: Document,
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {

--- a/packages/discordx/package.json
+++ b/packages/discordx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordx",
-  "version": "11.11.3",
+  "version": "11.12.0",
   "private": false,
   "description": "Create a discord bot with TypeScript and Decorators!",
   "keywords": [

--- a/packages/discordx/src/decorators/classes/DApplicationCommand.ts
+++ b/packages/discordx/src/decorators/classes/DApplicationCommand.ts
@@ -18,7 +18,7 @@ import { Method } from "./Method.js";
 
 interface CreateStructure {
   botIds?: string[];
-  defaultMemberPermissions?: PermissionResolvable | null;
+  defaultMemberPermissions?: PermissionResolvable | string | null;
   description: string;
   descriptionLocalizations?: LocalizationMap | null;
   dmPermission?: boolean;
@@ -38,7 +38,7 @@ export class DApplicationCommand extends Method {
   private _nameLocalizations: LocalizationMap | null;
   private _description: string;
   private _descriptionLocalizations: LocalizationMap | null;
-  private _defaultMemberPermissions: PermissionResolvable | null;
+  private _defaultMemberPermissions: PermissionResolvable | string | null;
   private _dmPermission: boolean;
   private _guilds: IGuild[];
   private _group?: string;
@@ -61,7 +61,7 @@ export class DApplicationCommand extends Method {
     this._description = value;
   }
 
-  get defaultMemberPermissions(): PermissionResolvable | null {
+  get defaultMemberPermissions(): PermissionResolvable | string | null {
     return this._defaultMemberPermissions;
   }
   set defaultMemberPermissions(value: PermissionResolvable | null) {

--- a/packages/discordx/src/decorators/classes/DApplicationCommandOption.ts
+++ b/packages/discordx/src/decorators/classes/DApplicationCommandOption.ts
@@ -23,6 +23,7 @@ import type {
 interface CreateStructure {
   autocomplete?: SlashAutoCompleteOption;
   channelType?: ChannelType[];
+  choices?: DApplicationCommandOptionChoice[];
   description: string;
   descriptionLocalizations?: LocalizationMap | null;
   index?: number;
@@ -168,6 +169,7 @@ export class DApplicationCommandOption extends Decorator {
     this._name = data.name;
     this._autocomplete = data.autocomplete;
     this._channelTypes = data.channelType?.sort();
+    this._choices = data.choices ?? [];
     this._description = data.description;
     this._index = data.index;
     this._maxValue = data.maxValue;

--- a/packages/discordx/src/decorators/decorators/Slash.ts
+++ b/packages/discordx/src/decorators/decorators/Slash.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------------------
  */
 import type { MethodDecoratorEx } from "@discordx/internal";
-import { ApplicationCommandType } from "discord.js";
+import { ApplicationCommandType, SlashCommandBuilder } from "discord.js";
 
 import type {
   ApplicationCommandOptions,
@@ -28,26 +28,76 @@ import {
  *
  * @category Decorator
  */
+export function Slash(options: SlashCommandBuilder): MethodDecoratorEx;
+
+/**
+ * Handle a slash command with a defined name
+ *
+ * @param options - Application command options
+ * ___
+ *
+ * [View Documentation](https://discordx.js.org/docs/discordx/decorators/command/slash)
+ *
+ * @category Decorator
+ */
 export function Slash<T extends string, TD extends string>(
   options: ApplicationCommandOptions<VerifyName<T>, NotEmpty<TD>>,
+): MethodDecoratorEx;
+
+/**
+ * Handle a slash command with a defined name
+ *
+ * @param options - Application command options
+ * ___
+ *
+ * [View Documentation](https://discordx.js.org/docs/discordx/decorators/command/slash)
+ *
+ * @category Decorator
+ */
+export function Slash<T extends string, TD extends string>(
+  options:
+    | ApplicationCommandOptions<VerifyName<T>, NotEmpty<TD>>
+    | SlashCommandBuilder,
 ): MethodDecoratorEx {
   return function (target: Record<string, any>, key: string) {
     const name = options.name ?? key;
     SlashNameValidator(name);
 
-    const applicationCommand = DApplicationCommand.create({
-      botIds: options.botIds,
-      defaultMemberPermissions: options.defaultMemberPermissions,
-      description: options.description,
-      descriptionLocalizations: options.descriptionLocalizations,
-      dmPermission: options.dmPermission ?? true,
-      guilds: options.guilds,
-      name: name,
-      nameLocalizations: options.nameLocalizations,
-      nsfw: options.nsfw,
-      type: ApplicationCommandType.ChatInput,
-    }).decorate(target.constructor, key, target[key]);
+    let applicationCommand: DApplicationCommand;
 
+    if (options instanceof SlashCommandBuilder) {
+      if (options.options.length > 0) {
+        throw Error(
+          "The builder options feature is not supported in discordx.",
+        );
+      }
+
+      applicationCommand = DApplicationCommand.create({
+        defaultMemberPermissions: options.default_member_permissions,
+        description: options.description,
+        descriptionLocalizations: options.description_localizations,
+        dmPermission: options.dm_permission ?? true,
+        name: name,
+        nameLocalizations: options.name_localizations,
+        nsfw: options.nsfw,
+        type: ApplicationCommandType.ChatInput,
+      });
+    } else {
+      applicationCommand = DApplicationCommand.create({
+        botIds: options.botIds,
+        defaultMemberPermissions: options.defaultMemberPermissions,
+        description: options.description,
+        descriptionLocalizations: options.descriptionLocalizations,
+        dmPermission: options.dmPermission ?? true,
+        guilds: options.guilds,
+        name: name,
+        nameLocalizations: options.nameLocalizations,
+        nsfw: options.nsfw,
+        type: ApplicationCommandType.ChatInput,
+      });
+    }
+
+    applicationCommand.decorate(target.constructor, key, target[key]);
     MetadataStorage.instance.addApplicationCommandSlash(applicationCommand);
   };
 }

--- a/packages/discordx/src/decorators/decorators/SlashOption.ts
+++ b/packages/discordx/src/decorators/decorators/SlashOption.ts
@@ -6,11 +6,28 @@
  */
 import type { ParameterDecoratorEx } from "@discordx/internal";
 import { Modifier } from "@discordx/internal";
+import {
+  SlashCommandAttachmentOption,
+  SlashCommandBooleanOption,
+  SlashCommandChannelOption,
+  SlashCommandIntegerOption,
+  SlashCommandMentionableOption,
+  SlashCommandNumberOption,
+  SlashCommandRoleOption,
+  SlashCommandStringOption,
+  SlashCommandUserOption,
+} from "discord.js";
 
-import type { NotEmpty, SlashOptionOptions, VerifyName } from "../../index.js";
+import type {
+  NotEmpty,
+  SlashOptionOptions,
+  TransformerFunction,
+  VerifyName,
+} from "../../index.js";
 import {
   DApplicationCommand,
   DApplicationCommandOption,
+  DApplicationCommandOptionChoice,
   MetadataStorage,
   SlashNameValidator,
 } from "../../index.js";
@@ -25,28 +42,154 @@ import {
  *
  * @category Decorator
  */
+export function SlashOption(
+  options:
+    | SlashCommandAttachmentOption
+    | SlashCommandBooleanOption
+    | SlashCommandChannelOption
+    | SlashCommandIntegerOption
+    | SlashCommandMentionableOption
+    | SlashCommandNumberOption
+    | SlashCommandRoleOption
+    | SlashCommandStringOption
+    | SlashCommandUserOption,
+  transformer?: TransformerFunction,
+): ParameterDecoratorEx;
+
+/**
+ * Add a slash command option
+ *
+ * @param options - Slash option options
+ * ___
+ *
+ * [View Documentation](https://discordx.js.org/docs/discordx/decorators/command/slash-option)
+ *
+ * @category Decorator
+ */
 export function SlashOption<T extends string, TD extends string>(
   options: SlashOptionOptions<VerifyName<T>, NotEmpty<TD>>,
+  transformer?: TransformerFunction,
+): ParameterDecoratorEx;
+
+/**
+ * Add a slash command option
+ *
+ * @param options - Slash option options
+ * ___
+ *
+ * [View Documentation](https://discordx.js.org/docs/discordx/decorators/command/slash-option)
+ *
+ * @category Decorator
+ */
+export function SlashOption<T extends string, TD extends string>(
+  options:
+    | SlashCommandAttachmentOption
+    | SlashCommandBooleanOption
+    | SlashCommandChannelOption
+    | SlashCommandIntegerOption
+    | SlashCommandMentionableOption
+    | SlashCommandNumberOption
+    | SlashCommandRoleOption
+    | SlashCommandStringOption
+    | SlashCommandUserOption
+    | SlashOptionOptions<VerifyName<T>, NotEmpty<TD>>,
+  transformer?: TransformerFunction,
 ): ParameterDecoratorEx {
   return function (target: Record<string, any>, key: string, index: number) {
     SlashNameValidator(options.name);
 
-    const option = DApplicationCommandOption.create({
-      autocomplete: options.autocomplete,
-      channelType: options.channelTypes,
-      description: options.description,
-      descriptionLocalizations: options.descriptionLocalizations,
-      index: index,
-      maxLength: options.maxLength,
-      maxValue: options.maxValue,
-      minLength: options.minLength,
-      minValue: options.minValue,
-      name: options.name,
-      nameLocalizations: options.nameLocalizations,
-      required: options.required,
-      transformer: options.transformer,
-      type: options.type,
-    }).decorate(
+    let option: DApplicationCommandOption;
+
+    if (
+      options instanceof SlashCommandAttachmentOption ||
+      options instanceof SlashCommandBooleanOption ||
+      options instanceof SlashCommandRoleOption ||
+      options instanceof SlashCommandMentionableOption ||
+      options instanceof SlashCommandUserOption
+    ) {
+      option = DApplicationCommandOption.create({
+        description: options.description,
+        descriptionLocalizations: options.description_localizations,
+        index: index,
+        name: options.name,
+        nameLocalizations: options.name_localizations,
+        required: options.required,
+        transformer,
+        type: options.type,
+      });
+    } else if (options instanceof SlashCommandChannelOption) {
+      option = DApplicationCommandOption.create({
+        channelType: options.channel_types,
+        description: options.description,
+        descriptionLocalizations: options.description_localizations,
+        index: index,
+        name: options.name,
+        nameLocalizations: options.name_localizations,
+        required: options.required,
+        transformer,
+        type: options.type,
+      });
+    } else if (
+      options instanceof SlashCommandIntegerOption ||
+      options instanceof SlashCommandNumberOption
+    ) {
+      const choices = options.choices?.map((choice) =>
+        DApplicationCommandOptionChoice.create(choice),
+      );
+
+      option = DApplicationCommandOption.create({
+        autocomplete: options.autocomplete,
+        choices,
+        description: options.description,
+        descriptionLocalizations: options.description_localizations,
+        index: index,
+        maxValue: options.max_value,
+        minValue: options.min_value,
+        name: options.name,
+        nameLocalizations: options.name_localizations,
+        required: options.required,
+        transformer,
+        type: options.type,
+      });
+    } else if (options instanceof SlashCommandStringOption) {
+      const choices = options.choices?.map((choice) =>
+        DApplicationCommandOptionChoice.create(choice),
+      );
+
+      option = DApplicationCommandOption.create({
+        autocomplete: options.autocomplete,
+        choices,
+        description: options.description,
+        descriptionLocalizations: options.description_localizations,
+        index: index,
+        maxLength: options.max_length,
+        minLength: options.min_length,
+        name: options.name,
+        nameLocalizations: options.name_localizations,
+        required: options.required,
+        transformer,
+        type: options.type,
+      });
+    } else {
+      option = DApplicationCommandOption.create({
+        autocomplete: options.autocomplete,
+        channelType: options.channelTypes,
+        description: options.description,
+        descriptionLocalizations: options.descriptionLocalizations,
+        index: index,
+        maxLength: options.maxLength,
+        maxValue: options.maxValue,
+        minLength: options.minLength,
+        minValue: options.minValue,
+        name: options.name,
+        nameLocalizations: options.nameLocalizations,
+        required: options.required,
+        transformer: transformer,
+        type: options.type,
+      });
+    }
+
+    option.decorate(
       target.constructor,
       key,
       target[key],

--- a/packages/discordx/src/types/public/slash.ts
+++ b/packages/discordx/src/types/public/slash.ts
@@ -14,11 +14,7 @@ import type {
   PermissionResolvable,
 } from "discord.js";
 
-import type {
-  DApplicationCommand,
-  IGuild,
-  TransformerFunction,
-} from "../../index.js";
+import type { DApplicationCommand, IGuild } from "../../index.js";
 
 export interface ApplicationCommandOptions<
   T extends string,
@@ -48,7 +44,6 @@ export interface SlashOptionBaseOptions<T extends string, TD extends string> {
   nameLocalizations?: LocalizationMap;
   nsfw?: boolean;
   required?: boolean;
-  transformer?: TransformerFunction;
   type: Exclude<
     ApplicationCommandOptionType,
     | ApplicationCommandOptionType.Subcommand
@@ -120,7 +115,7 @@ export type SlashAutoCompleteOption =
     ) => void | Promise<void>);
 
 export interface ApplicationCommandDataEx {
-  defaultMemberPermissions?: PermissionResolvable | null;
+  defaultMemberPermissions?: PermissionResolvable | string | null;
   description?: string;
   descriptionLocalizations?: LocalizationMap | null;
   dmPermission?: boolean;

--- a/packages/plugin-lava-player/package.json
+++ b/packages/plugin-lava-player/package.json
@@ -112,7 +112,7 @@
   },
   "devDependencies": {
     "discord.js": "^14.15.3",
-    "discordx": "^11.11.1",
+    "discordx": "^11.12.0",
     "ts-node": "^10.9.2"
   },
   "peerDependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -49,7 +49,7 @@
     "@discordx/importer": "^1.3.1",
     "@discordx/pagination": "^3.5.4",
     "discord.js": "^14.15.3",
-    "discordx": "^11.11.1",
+    "discordx": "^11.12.0",
     "typescript": "5.4.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
Example

```ts
import {
  SlashCommandBuilder,
  SlashCommandMentionableOption,
  User,
  type CommandInteraction,
} from "discord.js";
import { Discord, Slash, SlashOption } from "discordx";

const cmd = new SlashCommandBuilder()
  .setName("hello")
  .setDescription("Say hello!");

const user_option = new SlashCommandMentionableOption()
  .setName("user")
  .setDescription("Mention user to say hello to.")
  .setRequired(true);

@Discord()
export class Example {
  @Slash(cmd)
  async hello(
    @SlashOption(user_option) user: User,
    interaction: CommandInteraction,
  ): Promise<void> {
    await interaction.reply(`:wave: ${user}`);
  }
}

```