### PR TITLE
fix: track repeat modes

### DIFF
--- a/packages/lava-queue/CHANGELOG.md
+++ b/packages/lava-queue/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @discordx/lava-queue
 
+## 4.0.6
+
+### Patch Changes
+
+- fix: track repeat mode
+
 ## 4.0.5
 
 ### Patch Changes

--- a/packages/lava-queue/package.json
+++ b/packages/lava-queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordx/lava-queue",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "private": false,
   "description": "Queue system for @discordx/lava-player",
   "keywords": [

--- a/packages/lava-queue/src/queue.ts
+++ b/packages/lava-queue/src/queue.ts
@@ -164,11 +164,10 @@ export class Queue {
    */
   async playNext(): Promise<Track | null> {
     if (this.currentPlaybackTrack) {
-      if (
-        this.repeatMode === RepeatMode.REPEAT_ALL ||
-        (this.repeatMode === RepeatMode.REPEAT_ONE && this._tracks.length === 1)
-      ) {
+      if (this.repeatMode === RepeatMode.REPEAT_ALL) {
         this.addTrack(this.currentPlaybackTrack);
+      } else if (this.repeatMode === RepeatMode.REPEAT_ONE) {
+        this.addTrackFirst(this.currentPlaybackTrack);
       }
     }
 

--- a/packages/lava-queue/src/queue.ts
+++ b/packages/lava-queue/src/queue.ts
@@ -136,9 +136,9 @@ export class Queue {
   changeTrackPosition(oldIndex: number, newIndex: number): void {
     if (
       oldIndex < 0 ||
-      oldIndex >= this._tracks.length ||
+      oldIndex >= this.size ||
       newIndex < 0 ||
-      newIndex >= this._tracks.length
+      newIndex >= this.size
     ) {
       throw new Error("Invalid track position");
     }
@@ -163,23 +163,36 @@ export class Queue {
    * @returns The next track that was played or null if the queue is empty.
    */
   async playNext(): Promise<Track | null> {
-    if (this.currentPlaybackTrack) {
+    /**
+     * If repeat mode is on, process it
+     */
+    if (
+      this._currentPlaybackTrack !== null &&
+      this.repeatMode !== RepeatMode.OFF
+    ) {
       if (this.repeatMode === RepeatMode.REPEAT_ALL) {
-        this.addTrack(this.currentPlaybackTrack);
-      } else if (this.repeatMode === RepeatMode.REPEAT_ONE) {
-        this.addTrackFirst(this.currentPlaybackTrack);
+        this.addTrack(this._currentPlaybackTrack);
+      } else {
+        this.addTrackFirst(this._currentPlaybackTrack);
       }
     }
 
-    const track = this._tracks.shift();
-    if (!track) {
-      this._currentPlaybackTrack = null;
+    /**
+     * Set current track to null
+     */
+    this._currentPlaybackTrack = null;
+
+    /**
+     * Process next track
+     */
+    const nextTrack = this._tracks.shift();
+    if (!nextTrack) {
       return null;
     }
 
-    await this.guildPlayer.update({ track: { encoded: track.encoded } });
-    this._currentPlaybackTrack = track;
-    return track;
+    await this.guildPlayer.update({ track: { encoded: nextTrack.encoded } });
+    this._currentPlaybackTrack = nextTrack;
+    return nextTrack;
   }
 
   /**
@@ -198,7 +211,7 @@ export class Queue {
     // Sort indices in descending order to avoid shifting issues while removing
     indices.sort((a, b) => b - a);
     for (const index of indices) {
-      if (index >= 0 && index < this._tracks.length) {
+      if (index >= 0 && index < this.size) {
         this._tracks.splice(index, 1);
       }
     }

--- a/packages/music/CHANGELOG.md
+++ b/packages/music/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @discordx/music
 
+## 6.3.1
+
+### Patch Changes
+
+- fix: track repeat mode
+
 ## 6.3.0
 
 ### Minor Changes

--- a/packages/music/package.json
+++ b/packages/music/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordx/music",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "private": false,
   "description": "Powerful Discord music player library using YTDL",
   "keywords": [

--- a/packages/music/src/queue.ts
+++ b/packages/music/src/queue.ts
@@ -78,7 +78,7 @@ export class Queue<T extends Track = Track> {
     return this._volume;
   }
 
-  get queueSize(): number {
+  get size(): number {
     return this.tracks.length;
   }
 
@@ -134,9 +134,9 @@ export class Queue<T extends Track = Track> {
   public changeTrackPosition(oldIndex: number, newIndex: number): void {
     if (
       oldIndex < 0 ||
-      oldIndex >= this._tracks.length ||
+      oldIndex >= this.size ||
       newIndex < 0 ||
-      newIndex >= this._tracks.length
+      newIndex >= this.size
     ) {
       throw new Error("Invalid track position");
     }
@@ -191,9 +191,9 @@ export class Queue<T extends Track = Track> {
       this.repeatMode !== RepeatMode.OFF
     ) {
       if (this.repeatMode === RepeatMode.REPEAT_ALL) {
-        this._tracks.push(this._currentPlaybackTrack);
+        this.addTrack(this._currentPlaybackTrack);
       } else {
-        this._tracks.unshift(this._currentPlaybackTrack);
+        this.addTrackFirst(this._currentPlaybackTrack);
       }
     }
 
@@ -231,7 +231,7 @@ export class Queue<T extends Track = Track> {
     // Sort indices in descending order to avoid shifting issues while removing
     indices.sort((a, b) => b - a);
     for (const index of indices) {
-      if (index >= 0 && index < this._tracks.length) {
+      if (index >= 0 && index < this.size) {
         this._tracks.splice(index, 1);
       }
     }

--- a/packages/plugin-lava-player/CHANGELOG.md
+++ b/packages/plugin-lava-player/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @discordx/plugin-lava-player
 
+## 2.5.5
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @discordx/lava-queue@4.0.6
+
 ## 2.5.4
 
 ### Patch Changes

--- a/packages/plugin-lava-player/package.json
+++ b/packages/plugin-lava-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordx/plugin-lava-player",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "private": false,
   "description": "Fully-featured Discord music player leveraging the power of Lavalink",
   "keywords": [

--- a/packages/plugin-ytdl-player/CHANGELOG.md
+++ b/packages/plugin-ytdl-player/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @discordx/plugin-ytdl-player
 
+## 2.3.5
+
+### Patch Changes
+
+- update queue
+
 ## 2.3.4
 
 ### Patch Changes

--- a/packages/plugin-ytdl-player/CHANGELOG.md
+++ b/packages/plugin-ytdl-player/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @discordx/plugin-ytdl-player
 
+## 2.3.4
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @discordx/music@6.3.1
+
 ## 2.3.3
 
 ### Patch Changes

--- a/packages/plugin-ytdl-player/package.json
+++ b/packages/plugin-ytdl-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordx/plugin-ytdl-player",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "private": false,
   "description": "Fully-featured Discord music player utilizing YTDL",
   "keywords": [

--- a/packages/plugin-ytdl-player/package.json
+++ b/packages/plugin-ytdl-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discordx/plugin-ytdl-player",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "private": false,
   "description": "Fully-featured Discord music player utilizing YTDL",
   "keywords": [

--- a/packages/plugin-ytdl-player/src/core/queue.ts
+++ b/packages/plugin-ytdl-player/src/core/queue.ts
@@ -132,9 +132,7 @@ export class MusicQueue extends Queue<MyTrack> {
     const user = currentTrack.user;
     embed.addFields({
       name: `Now Playing${
-        this.queueSize > 2
-          ? `(Total: ${String(this.queueSize)} tracks queued)`
-          : ""
+        this.size > 2 ? `(Total: ${String(this.size)} tracks queued)` : ""
       }`,
       value: `[${currentTrack.title}](${currentTrack.url}) by ${user.toString()}`,
     });

--- a/packages/plugin-ytdl-player/src/utils/queue.ts
+++ b/packages/plugin-ytdl-player/src/utils/queue.ts
@@ -32,7 +32,7 @@ export async function showQueue(
     return;
   }
 
-  if (!queue.queueSize) {
+  if (!queue.size) {
     const pMsg = await interaction.followUp({
       content: `> Playing **${currentTrack.title}**`,
       embeds: currentTrack.thumbnail
@@ -47,12 +47,12 @@ export async function showQueue(
   }
 
   const current = `> Playing **${currentTrack.title}** out of ${String(
-    queue.queueSize + 1,
+    queue.size + 1,
   )}`;
 
   const pageOptions = new PaginationResolver(
     (index, paginator) => {
-      paginator.maxLength = queue.queueSize / 10;
+      paginator.maxLength = queue.size / 10;
       if (index > paginator.maxLength) {
         paginator.currentPage = 0;
       }
@@ -70,17 +70,17 @@ export async function showQueue(
 
       return { content: `${current}\n\`\`\`markdown\n${tracks}\`\`\`` };
     },
-    Math.floor(queue.queueSize / 10),
+    Math.floor(queue.size / 10),
   );
 
   await new Pagination(interaction, pageOptions, {
     enableExit: true,
-    onTimeout: (index, message) => {
+    onTimeout: (_, message) => {
       void deleteMessage(message);
     },
     time: 6e4,
     type:
-      Math.floor(queue.queueSize / 10) <= 5
+      Math.floor(queue.size / 10) <= 5
         ? PaginationType.Button
         : PaginationType.SelectMenu,
   }).send();


### PR DESCRIPTION
- Repeat mode does not work if the queue is empty, even if there is a track playing.
- The `REPEAT_ONE` is repeating all tracks instead of only the current track.