### PR TITLE
fix: memory leak in event triggers

### DIFF
--- a/packages/discordx/CHANGELOG.md
+++ b/packages/discordx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # discordx
 
+## 11.12.2
+
+### Patch Changes
+
+- fix memory leak in event triggers
+
 ## 11.12.1
 
 ### Patch Changes

--- a/packages/discordx/package.json
+++ b/packages/discordx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discordx",
-  "version": "11.12.1",
+  "version": "11.12.2",
   "private": false,
   "description": "Create a discord bot with TypeScript and Decorators!",
   "keywords": [

--- a/packages/discordx/src/logic/metadata/MetadataStorage.ts
+++ b/packages/discordx/src/logic/metadata/MetadataStorage.ts
@@ -588,8 +588,6 @@ export class MetadataStorage {
    * @param options - Even data
    */
   trigger(options: ITriggerEventData): (...params: any[]) => any {
-    const responses: any[] = [];
-
     const eventsToExecute = this._events.filter((on) => {
       return (
         on.event === options.event &&
@@ -599,6 +597,7 @@ export class MetadataStorage {
     });
 
     return async (...params: any[]) => {
+      const responses: any[] = [];
       await Promise.all(
         eventsToExecute.map(async (ev) => {
           if (!ev.isBotAllowed(options.client.botId)) {


### PR DESCRIPTION
**Please describe the changes this PR makes:**
The trigger creates a "trigger" function which saves the context into the _listeners map in the client.

Each time this function get's triggered the response is pushed into the responses array, which is created once, on startup. This causes a memory leak which saves all responses during the lifetime of the bot.

By moving the respones array into the function itself this is resolved and it will only return the responses for that specific trigger and the array can be garbage collected after this.

For a quick example of this bug on production (running for around a week with 100k members):
![{74CE638F-7DDE-4B3D-BC85-BE8B558F2492}](https://github.com/user-attachments/assets/313cccfd-f82a-458b-a11e-9f6bf38f9c4d)

This array uses about 250 MB of memory, which is about 90% of all memory usage, and the array only contains empty objects returned from the execute function.