### PR TITLE
docs: specify converters & add bun to docusaurus config

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -75,7 +75,7 @@ module.exports = {
         docs: {
           editUrl: "https://github.com/discordx-ts/discordx/edit/main/docs/",
           remarkPlugins: [
-            [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
+            [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true, converters: ['yarn', 'pnpm', 'bun'] }],
           ],
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,


### PR DESCRIPTION
**Please describe the changes this PR makes:**
As with the latest [update](https://github.com/discordx-ts/discordx/commit/c6b7d4abe9bd02e2490cc74bfa3a6d6e521b4440) to `create-discordx` with v1.3.0 , this adds bun to the docs as well.