### PR TITLE
docs: update 'ready' event to 'clientReady' to address deprecation

### DIFF
--- a/docs/docs/discordx/getting-started.mdx
+++ b/docs/docs/discordx/getting-started.mdx
@@ -165,7 +165,7 @@ const client = new Client({
   silent: false,
 });
 
-client.on("ready", async () => {
+client.on("clientReady", async () => {
   console.log(">> Bot started");
 
   // to create/update/delete discord application commands


### PR DESCRIPTION
Update documentation to use 'clientReady' instead of the deprecated 'ready' event name, following discord.js v15 changes where 'ready' has been renamed to 'clientReady' to distinguish it from the gateway READY event.

**Please describe the changes this PR makes:**
